### PR TITLE
Implement targeted vpn, security, and logging fixes

### DIFF
--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 write_aliases_file() {
-  msg "📄 Generating helper aliases file"
+  msg "🛠️ Generating helper aliases file"
 
   local template_file="${REPO_ROOT}/.aliasarr"
   local aliases_file="${ARR_STACK_DIR}/.aliasarr"

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -95,7 +95,7 @@ arrstack_setup_defaults() {
   local requested_permission_profile="${ARR_PERMISSION_PROFILE:-}"
   local permission_profile="${requested_permission_profile:-strict}"
   SECRET_FILE_MODE=600
-  LOCK_FILE_MODE=644
+  LOCK_FILE_MODE=640
   NONSECRET_FILE_MODE=600
   DATA_DIR_MODE=700
   local collab_initial_umask="0007"

--- a/scripts/export-caddy-ca.sh
+++ b/scripts/export-caddy-ca.sh
@@ -29,7 +29,7 @@ if [[ ! -d "${dest_dir}" ]]; then
 fi
 
 if cp "$CA_FILE" "$DEST_FILE" 2>/dev/null; then
-  chmod 600 "$DEST_FILE" 2>/dev/null || true
+  chmod 640 "$DEST_FILE" 2>/dev/null || true
   log_info "CA certificate exported to ${DEST_FILE}"
   log_info "Install this on LAN devices to trust HTTPS connections"
 else

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -206,8 +206,7 @@ install_vuetorrent() {
     write_qbt_config
   fi
 
-  docker ps -a --filter "label=com.docker.compose.project=arrstack" --format "{{.ID}}" \
-    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  # Removed aggressive container cleanup to avoid disrupting other services mid-run.
 }
 
 service_container_name() {


### PR DESCRIPTION
## Summary
- update vpn auto-reconnect to skip recent failures, use precise load thresholds, and tidy rotation handling
- harden networking and credential flows by validating LAN_IP, generating alphanumeric API keys, refining Gluetun auth detection, and cleaning qBittorrent hook cookies
- improve privilege escalation safety, adjust default permissions, and standardize high-level logging cues

## Testing
- shellcheck scripts/vpn-auto-reconnect.sh scripts/services.sh scripts/files.sh scripts/gluetun.sh scripts/common.sh scripts/defaults.sh scripts/export-caddy-ca.sh scripts/aliases.sh

------
https://chatgpt.com/codex/tasks/task_e_68dba89341088329a56535f295c0ac75