### PR TITLE
Allow forced Configarr API key secret updates

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -218,7 +218,7 @@ main() {
 
   # shellcheck disable=SC2034 # values consumed by scripts/summary.sh
   if [[ "${FORCE_SYNC_API_KEYS:-0}" -eq 1 ]]; then
-    arrstack_sync_arr_api_keys || true
+    arrstack_sync_arr_api_keys 1 || true
   elif [[ "${DISABLE_AUTO_API_KEY_SYNC:-0}" -eq 1 ]]; then
     API_KEYS_SYNCED_STATUS="disabled"
     API_KEYS_SYNCED_MESSAGE="Configarr API key sync skipped (--no-auto-api-sync)."
@@ -226,7 +226,7 @@ main() {
       API_KEYS_SYNCED_PLACEHOLDERS=1
     fi
   else
-    arrstack_sync_arr_api_keys || true
+    arrstack_sync_arr_api_keys 0 || true
   fi
 
   if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 && "${ENABLE_CADDY:-0}" -eq 1 ]]; then

--- a/scripts/apikeys.sh
+++ b/scripts/apikeys.sh
@@ -125,12 +125,7 @@ arrstack_update_secret_line() {
     fi
   fi
 
-  local should_update=0
-  if (( placeholder == 1 )); then
-    should_update=1
-  elif (( force_update == 1 )); then
-    should_update=1
-  fi
+  local should_update=$(( placeholder == 1 || force_update == 1 ))
 
   if (( should_update == 0 )); then
     printf 'unchanged\n'

--- a/scripts/apikeys.sh
+++ b/scripts/apikeys.sh
@@ -51,6 +51,16 @@ arrstack_update_secret_line() {
   local secrets_file="$1"
   local secret_key="$2"
   local new_value="$3"
+  local force_input="${4:-}"
+
+  if [[ -z "$force_input" ]]; then
+    force_input="${FORCE_SYNC_API_KEYS:-0}"
+  fi
+
+  local force_update=0
+  if [[ "$force_input" == "1" ]]; then
+    force_update=1
+  fi
 
   if [[ -z "$secrets_file" || -z "$secret_key" || -z "$new_value" ]]; then
     return 1
@@ -115,7 +125,14 @@ arrstack_update_secret_line() {
     fi
   fi
 
-  if (( placeholder == 0 )); then
+  local should_update=0
+  if (( placeholder == 1 )); then
+    should_update=1
+  elif (( force_update == 1 )); then
+    should_update=1
+  fi
+
+  if (( should_update == 0 )); then
     printf 'unchanged\n'
     return 0
   fi
@@ -129,6 +146,8 @@ arrstack_update_secret_line() {
 }
 
 arrstack_sync_arr_api_keys() {
+  local force_sync="${1:-${FORCE_SYNC_API_KEYS:-0}}"
+
   API_KEYS_SYNCED_STATUS=""
   API_KEYS_SYNCED_MESSAGE=""
   API_KEYS_SYNCED_DETAILS=""
@@ -196,7 +215,7 @@ arrstack_sync_arr_api_keys() {
     fi
 
     local result=""
-    if result="$(arrstack_update_secret_line "$secrets_file" "$secret_key" "$api_key" 2>/dev/null)"; then
+    if result="$(arrstack_update_secret_line "$secrets_file" "$secret_key" "$api_key" "$force_sync" 2>/dev/null)"; then
       case "$result" in
         updated|created|appended)
           status_map[$service]="updated"


### PR DESCRIPTION
## Summary
- let `arrstack_update_secret_line` accept a force flag (or `FORCE_SYNC_API_KEYS=1`) so rotated API keys overwrite populated secrets
- thread the force flag through `arrstack_sync_arr_api_keys` and the `arrstack.sh` callers for normal vs. forced sync flows

## Testing
- bash -lc 'source scripts/common.sh; source scripts/apikeys.sh; tmp=$(mktemp -d); trap "rm -rf "$tmp"" EXIT; mkdir -p "$tmp"/configarr "$tmp"/sonarr "$tmp"/radarr "$tmp"/prowlarr; cat <<EOF >"$tmp/configarr/secrets.yml"
SONARR_API_KEY: "OLDSONARRKEY1"
RADARR_API_KEY: "OLDRADARRKEY1"
PROWLARR_API_KEY: "OLDPROWLARR1"
EOF
cat <<EOF >"$tmp/sonarr/config.xml"
<Config><ApiKey>NEWSONARRKEY2</ApiKey></Config>
EOF
cat <<EOF >"$tmp/radarr/config.xml"
<Config><ApiKey>NEWRADARRKEY2</ApiKey></Config>
EOF
cat <<EOF >"$tmp/prowlarr/config.xml"
<Config><ApiKey>NEWPROWLARRK2</ApiKey></Config>
EOF
ARR_DOCKER_DIR="$tmp" ENABLE_CONFIGARR=1 FORCE_SYNC_API_KEYS=0 arrstack_sync_arr_api_keys 0
echo "--- secrets after normal sync ---"
cat "$tmp/configarr/secrets.yml"'
- bash -lc 'source scripts/common.sh; source scripts/apikeys.sh; tmp=$(mktemp -d); trap "rm -rf "$tmp"" EXIT; mkdir -p "$tmp"/configarr "$tmp"/sonarr "$tmp"/radarr "$tmp"/prowlarr; cat <<EOF >"$tmp/configarr/secrets.yml"
SONARR_API_KEY: "OLDSONARRKEY1"
RADARR_API_KEY: "OLDRADARRKEY1"
PROWLARR_API_KEY: "OLDPROWLARR1"
EOF
cat <<EOF >"$tmp/sonarr/config.xml"
<Config><ApiKey>NEWSONARRKEY2</ApiKey></Config>
EOF
cat <<EOF >"$tmp/radarr/config.xml"
<Config><ApiKey>NEWRADARRKEY2</ApiKey></Config>
EOF
cat <<EOF >"$tmp/prowlarr/config.xml"
<Config><ApiKey>NEWPROWLARRK2</ApiKey></Config>
EOF
ARR_DOCKER_DIR="$tmp" ENABLE_CONFIGARR=1 FORCE_SYNC_API_KEYS=1 arrstack_sync_arr_api_keys 1
echo "--- secrets after forced sync ---"
cat "$tmp/configarr/secrets.yml"'

------
https://chatgpt.com/codex/tasks/task_e_68dc536e35d0832981b7bca5178e7976