### PR TITLE
docs: streamline README and modular documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,25 @@
-# arrstack-mini
+# arrbash
 
-Self-host the *arr stack with Proton VPN port forwarding on a Debian or Raspberry Pi 5 host in minutes.
+Self-host the *arr stack with Proton VPN port forwarding on a Debian-based host.
 
 ## What you get
-- Proton-enabled qBittorrent behind Gluetun with automatic port forwarding.
+- qBittorrent running through Gluetun with automatic Proton port forwarding.
 - Sonarr, Radarr, Prowlarr, Bazarr, and FlareSolverr on the LAN bridge.
-- Optional extras: Caddy HTTPS proxy, local DNS, Configarr sync, VueTorrent WebUI.
+- Optional extras: Caddy HTTPS proxy, local DNS resolver, Configarr sync, VueTorrent WebUI.
 
 ## Prerequisites
-- 64-bit Debian Bookworm host (Pi 5 recommended) with static LAN IP, 4 CPU cores, and 4 GB RAM.
-- Proton VPN Plus or Unlimited account (required for port forwarding).
-- Docker Engine + Compose plugin and basic CLI tools (`git`, `curl`, `jq`, `openssl`). Install them once:
-  ```bash
-  sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    git curl jq openssl docker.io docker-compose-plugin
-  ```
+- 64-bit Debian 12 (Bookworm) or equivalent with a static LAN IP, 4 CPU cores, and 4 GB RAM.
+- Proton VPN Plus or Unlimited subscription for port forwarding support.
+- Docker Engine with the Compose plugin, plus `git`, `curl`, `jq`, and `openssl` installed.
 
 ## Quick start
-1. **Clone the repo.**
+1. **Clone arrbash and enter the directory.**
    ```bash
    mkdir -p ~/srv && cd ~/srv
-   git clone https://github.com/cbkii/arrstackmini.git
-   cd arrstackmini
+   git clone https://github.com/cbkii/arrbash.git
+   cd arrbash
    ```
-2. **Create Proton credentials.**
+2. **Add Proton credentials.**
    ```bash
    cp arrconf/proton.auth.example arrconf/proton.auth
    nano arrconf/proton.auth    # set PROTON_USER and PROTON_PASS (the script appends +pmp)
@@ -33,40 +28,35 @@ Self-host the *arr stack with Proton VPN port forwarding on a Debian or Raspberr
 3. **Create your overrides.**
    ```bash
    cp arrconf/userr.conf.example ../userr.conf
-   nano ../userr.conf          # at minimum set LAN_IP, DOWNLOADS_DIR, COMPLETED_DIR, MEDIA_DIR
+   nano ../userr.conf          # set LAN_IP, DOWNLOADS_DIR, COMPLETED_DIR, MEDIA_DIR
    ```
 4. **Run the installer.**
    ```bash
    ./arrstack.sh --yes         # omit --yes for interactive mode
    ```
-   The script installs prerequisites, renders `.env`, `docker-compose.yml`, and starts the stack. Rerun it anytime after editing `userr.conf`.
-5. **Load helper aliases (optional).**
-   ```bash
-   source "${ARR_STACK_DIR:-$(pwd)}/.aliasarr"
-   ```
-   Helpers like `arr.vpn.status`, `arr.logs`, and `arr.vpn.port` become available in the current shell.
-6. **Access the services.** Browse to `http://LAN_IP:PORT` (for example `http://192.168.1.50:8080` for qBittorrent). The installer prints a summary with exact URLs.
+   The script installs prerequisites, renders `.env` and `docker-compose.yml`, and starts the stack. Rerun it anytime after editing `userr.conf`.
+5. **Access services.** Use the summary printed by the installer or browse to `http://LAN_IP:PORT` (for example `http://192.168.1.50:8080` for qBittorrent).
 
 ## Minimal configuration
 - `userr.conf` lives at `${ARR_BASE:-$HOME/srv}/userr.conf`; keep it outside version control.
-- Key values to review:
-  - `LAN_IP`: private address of the host (stack refuses to expose ports until set).
-  - `ARR_BASE`: base directory for data (defaults to `~/srv`).
+- Review these core values:
+  - `LAN_IP`: private address of the host; required before ports are exposed.
+  - `ARR_BASE`: base directory for generated files (defaults to `~/srv`).
   - `DOWNLOADS_DIR`, `COMPLETED_DIR`, `MEDIA_DIR`: map to your storage paths.
   - `SPLIT_VPN`: set to `1` to tunnel only qBittorrent; leave `0` for full VPN mode.
-  - `ENABLE_CADDY`, `ENABLE_LOCAL_DNS`: toggle optional HTTPS/DNS profiles (see [Networking](./docs/networking.md)).
-- The installer preserves secrets such as `QBT_USER`, `QBT_PASS`, and `GLUETUN_API_KEY` between runs. Rotate them with `./arrstack.sh --rotate-api-key` or `./arrstack.sh --rotate-caddy-auth` when needed.
-- View available flags at any time with:
+  - `ENABLE_CADDY`, `ENABLE_LOCAL_DNS`, `ENABLE_CONFIGARR`: toggle optional HTTPS/DNS/Configarr services.
+- Secrets such as `QBT_USER`, `QBT_PASS`, and `GLUETUN_API_KEY` persist across runs. Rotate them with `./arrstack.sh --rotate-api-key` or `./arrstack.sh --rotate-caddy-auth`.
+- Show available flags at any time:
   ```bash
   ./arrstack.sh --help
   ```
 
 ## Next steps
-- Review [Configuration](./docs/configuration.md) for all supported variables and permission profiles.
-- Read [Networking](./docs/networking.md) before enabling split VPN, local DNS, or HTTPS.
-- Keep [Operations](./docs/operations.md) handy for helper scripts, rotation commands, and rerun guidance.
-- Check [Security](./docs/security.md) prior to exposing services beyond your LAN.
-- Use [Troubleshooting](./docs/troubleshooting.md) for common recovery steps.
+- Read [Configuration](./docs/configuration.md) for variable precedence and permission profiles.
+- Follow [Networking](./docs/networking.md) before enabling split VPN, local DNS, or HTTPS.
+- Keep [Operations](./docs/operations.md) nearby for helper scripts, rotation commands, and rerun guidance.
+- Review [Security](./docs/security.md) prior to exposing services beyond your LAN.
+- Bookmark [Troubleshooting](./docs/troubleshooting.md) for recovery steps.
 
 ## Documentation index
 - [Architecture](./docs/architecture.md) – container map, generated files, and installer flow.
@@ -74,12 +64,12 @@ Self-host the *arr stack with Proton VPN port forwarding on a Debian or Raspberr
 - [Networking](./docs/networking.md) – VPN modes, port forwarding, DNS, and HTTPS guidance.
 - [Operations](./docs/operations.md) – script reference, aliases, and recurring tasks.
 - [Security](./docs/security.md) – credential handling, exposure guidance, and verification checks.
-- [Troubleshooting](./docs/troubleshooting.md) – diagnosis steps and targeted fixes.
-- [Version management](./docs/version-management.md) – safe process for adjusting image tags.
+- [Troubleshooting](./docs/troubleshooting.md) – diagnostic steps and targeted fixes.
+- [Version management](./docs/version-management.md) – process for adjusting image tags safely.
 - [FAQ](./docs/faq.md) and [Glossary](./docs/glossary.md) – quick answers and terminology.
 
 ## Support & contributions
-Open an issue or PR if you find bugs or documentation gaps. Run `./arrstack.sh --help` and the docs before filing reports to confirm behaviour. Follow repository coding standards when submitting changes.
+Open an issue or PR for bugs or documentation gaps. Review `./arrstack.sh --help` and the docs before filing reports to confirm behaviour.
 
 ## License
 [MIT](./LICENSE)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose / Role of Agent
 
-You are an AI coding agent for the `cbkii/arrstackmini` project. Your responsibilities include:
+You are an AI coding agent for the `cbkii/arrbash` project. Your responsibilities include:
 
 - Editing, improving, and extending code, shell scripts, config files, and documentation.
 - Ensuring consistency between docs, examples, and code behavior.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,8 +36,8 @@ Generated files should not be edited manually; adjust `userr.conf` and rerun the
 
 Understanding this flow helps when troubleshooting: re-running the installer replays the entire pipeline and reconciles drift automatically.
 
-## See also
-- [Configuration](configuration.md) to adjust inputs.
-- [Networking](networking.md) for VPN, DNS, and HTTPS behaviour.
-- [Operations](operations.md) for command references.
-- [Troubleshooting](troubleshooting.md) to diagnose startup issues.
+## Related topics
+- [Configuration](configuration.md) – adjust installer inputs.
+- [Networking](networking.md) – understand VPN, DNS, and HTTPS behaviour.
+- [Operations](operations.md) – command references.
+- [Troubleshooting](troubleshooting.md) – diagnose startup issues.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ The installer prints a configuration table during preflight. Cancel with `Ctrl+C
   grep -E '^QBT_(USER|PASS)=' .env
   ```
 
-## See also
-- [Operations](operations.md) for helper scripts and command-line flags.
-- [Networking](networking.md) before enabling split VPN, DNS, or HTTPS.
-- [Security](security.md) for exposure and credential hygiene guidance.
+## Related topics
+- [Operations](operations.md) – helper scripts and command-line flags.
+- [Networking](networking.md) – VPN, DNS, and HTTPS considerations.
+- [Security](security.md) – exposure and credential hygiene guidance.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,10 +2,10 @@
 
 # Frequently asked questions
 
-Quick answers to common beginner questions about arrstack-mini.
+Quick answers to common beginner questions about arrbash.
 
 ## Do I need a Raspberry Pi 5?
-The stack targets Raspberry Pi 5 or any 64-bit Debian Bookworm host with similar resources (4 cores, 4 GB RAM). Slower hardware may work but downloads and transcoding will lag.
+Any 64-bit Debian Bookworm host with roughly 4 CPU cores and 4 GB RAM works. Raspberry Pi 5 is a popular option but not required.
 
 ## Which Proton plan should I buy?
 Use Proton VPN Plus or Unlimited. Those plans support port forwarding, which qBittorrent needs for good performance.
@@ -31,7 +31,7 @@ Use Caddy with strong basic auth if you need remote access. Avoid forwarding raw
 ## Is `home.arpa` required?
 It is the recommended LAN suffix because it never leaks to the public Internet. Change it only if another system already uses it.
 
-## See also
+## Related topics
 - [Configuration](configuration.md)
 - [Networking](networking.md)
 - [Operations](operations.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,7 +21,7 @@ Key terms referenced throughout the documentation.
 
 If a term is unfamiliar, follow links in the other docs or run `man <term>` on Debian (for example, `man resolv.conf`).
 
-## See also
+## Related topics
 - [Networking](networking.md)
 - [Operations](operations.md)
 - [FAQ](faq.md)

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -74,8 +74,8 @@ ss -ulpn | grep ':53 '
   ```
 - Runtime status lives in `${ARR_STACK_DIR}/.vpn-auto-reconnect-status.json`; detailed logs sit under `docker-data/gluetun/auto-reconnect/`.
 
-## See also
-- [Configuration](configuration.md) for the variables mentioned above.
-- [Operations](operations.md) for script details and command summaries.
-- [Security](security.md) for exposure and certificate handling guidance.
-- [Troubleshooting](troubleshooting.md) if DNS, HTTPS, or VPN tasks fail.
+## Related topics
+- [Configuration](configuration.md) – variables referenced above.
+- [Operations](operations.md) – script details and command summaries.
+- [Security](security.md) – exposure and certificate handling guidance.
+- [Troubleshooting](troubleshooting.md) – DNS, HTTPS, or VPN recovery steps.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -57,8 +57,8 @@ Run these from the repository root:
    ```
 4. Rotate secrets periodically using the dedicated flags or helpers (`--rotate-api-key`, `--rotate-caddy-auth`, `scripts/qbt-helper.sh reset`).
 
-## See also
-- [Configuration](configuration.md) for variable reference.
-- [Networking](networking.md) for VPN, DNS, and HTTPS guidance.
-- [Security](security.md) before exposing services beyond your LAN.
-- [Troubleshooting](troubleshooting.md) if checks fail.
+## Related topics
+- [Configuration](configuration.md) – variable reference.
+- [Networking](networking.md) – VPN, DNS, and HTTPS guidance.
+- [Security](security.md) – exposure checks before publishing services.
+- [Troubleshooting](troubleshooting.md) – follow-up when checks fail.

--- a/docs/security.md
+++ b/docs/security.md
@@ -32,8 +32,8 @@ Keep the deployment private to your LAN and rotate credentials regularly.
   git grep -nE '(yourname|@|home\\.local)'
   ```
 
-## See also
-- [Configuration](configuration.md) for permission profile details.
-- [Networking](networking.md) before enabling Caddy or local DNS.
-- [Operations](operations.md) for rotation commands.
-- [Troubleshooting](troubleshooting.md) for recovery steps.
+## Related topics
+- [Configuration](configuration.md) – permission profile details.
+- [Networking](networking.md) – Caddy, DNS, and VPN context.
+- [Operations](operations.md) – rotation commands.
+- [Troubleshooting](troubleshooting.md) – recovery steps.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -120,7 +120,7 @@ Follow these checks when services fail to start, DNS stops resolving, or VPN hel
   ```
   The script repeats DNS, port, and HTTPS checks using your generated configuration.
 
-## See also
-- [Networking](networking.md) for VPN, DNS, and HTTPS setup details.
-- [Operations](operations.md) for helper command summaries.
-- [Security](security.md) when reviewing exposure concerns.
+## Related topics
+- [Networking](networking.md) – VPN, DNS, and HTTPS setup details.
+- [Operations](operations.md) – helper command summaries.
+- [Security](security.md) – exposure considerations.

--- a/docs/version-management.md
+++ b/docs/version-management.md
@@ -2,7 +2,7 @@
 
 # Version management
 
-Track container tags safely so installs stay reproducible.
+Track container tags safely so arrbash installs stay reproducible.
 
 ## Why
 The stack pins each image to a tested tag. Registries occasionally remove old manifests; the helper scripts swap to `:latest` automatically for LinuxServer images when necessary.
@@ -22,8 +22,8 @@ The stack pins each image to a tested tag. Registries occasionally remove old ma
 ## Update workflow
 1. Back up your data:
    ```bash
-   cd "${ARR_STACK_DIR:-$PWD}/.."
-   tar -czf "arrstack-backup-$(date +%Y%m%d).tar.gz" arrstack docker-data
+   cd "${ARR_BASE:-$HOME/srv}"
+   tar -czf "arrbash-backup-$(date +%Y%m%d).tar.gz" "$(basename "${ARR_STACK_DIR:-arrstack}")" docker-data
    ```
 2. Edit `${ARR_BASE}/userr.conf` to change any `*_IMAGE` values.
 3. Apply changes:
@@ -60,8 +60,8 @@ List the images in use and confirm the expected tags appear:
 docker compose images
 ```
 
-## See also
-- [Configuration](configuration.md) for editing `*_IMAGE` overrides.
-- [Operations](operations.md) for rerun commands and helpers.
-- [Security](security.md) before exposing updated services.
-- [Troubleshooting](troubleshooting.md) if containers fail after a tag change.
+## Related topics
+- [Configuration](configuration.md) – edit `*_IMAGE` overrides.
+- [Operations](operations.md) – rerun commands and helpers.
+- [Security](security.md) – checks before exposing updated services.
+- [Troubleshooting](troubleshooting.md) – container recovery steps.


### PR DESCRIPTION
## Summary
- rewrite the top-level README as a concise quick-start for arrbash
- move advanced guidance into refreshed docs with consistent "Related topics" navigation
- replace legacy arrstackmini references and align docs with current helper flags and workflows

## Impact
- beginners can install quickly while deeper configuration, networking, and maintenance live in focused pages

## Actions
- none

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dc53025b7c8329aa970d5d3b4d2c32