### PR TITLE
Fix host DNS helper scripts to detect docker compose CLI

### DIFF
--- a/scripts/host-dns-rollback.sh
+++ b/scripts/host-dns-rollback.sh
@@ -3,6 +3,48 @@
 
 set -euo pipefail
 
+HOST_DNS_VERBOSE="${HOST_DNS_VERBOSE:-0}"
+
+resolve_docker_compose_cmd() {
+  local -a candidate=()
+  local version=""
+  local major=""
+
+  if docker compose version >/dev/null 2>&1; then
+    candidate=(docker compose)
+    version="$(docker compose version --short 2>/dev/null || true)"
+    version="${version#v}"
+    major="${version%%.*}"
+    if [[ -n "$version" && ! "$major" =~ ^[0-9]+$ ]]; then
+      version=""
+    fi
+  fi
+
+  if ((${#candidate[@]} == 0)) && command -v docker-compose >/dev/null 2>&1; then
+    version="$(docker-compose version --short 2>/dev/null || true)"
+    version="${version#v}"
+    major="${version%%.*}"
+    if [[ "$major" =~ ^[0-9]+$ ]] && ((major >= 2)); then
+      candidate=(docker-compose)
+    else
+      version=""
+    fi
+  fi
+
+  if ((${#candidate[@]} == 0)); then
+    echo "[error] Docker Compose v2+ is required but not found." >&2
+    exit 1
+  fi
+
+  DOCKER_COMPOSE_CMD=("${candidate[@]}")
+
+  if [[ "$HOST_DNS_VERBOSE" == "1" ]]; then
+    echo "[info] Using Docker Compose command: ${DOCKER_COMPOSE_CMD[*]}${version:+ (version ${version})}"
+  fi
+}
+
+DOCKER_COMPOSE_CMD=()
+
 if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   if command -v sudo >/dev/null 2>&1; then
     exec sudo -E "$0" "$@"
@@ -20,7 +62,8 @@ STUB="/run/systemd/resolve/stub-resolv.conf"
 REAL="/run/systemd/resolve/resolv.conf"
 
 echo "[info] Stopping local_dns (dnsmasq) container (optional)"
-docker compose stop local_dns || true
+resolve_docker_compose_cmd
+"${DOCKER_COMPOSE_CMD[@]}" stop local_dns || true
 
 echo "[info] Re-enabling systemd-resolved"
 systemctl enable --now "${RESOLVED_UNIT}"

--- a/scripts/host-dns-setup.sh
+++ b/scripts/host-dns-setup.sh
@@ -18,6 +18,45 @@ arrstack_escalate_privileges "$@" || exit $?
 # -E included to preserve ERR trap behavior in function/subshell contexts (Bash manual §"The ERR Trap").
 set -Eeuo pipefail
 
+HOST_DNS_VERBOSE="${HOST_DNS_VERBOSE:-0}"
+
+resolve_docker_compose_cmd() {
+  local -a candidate=()
+  local version=""
+  local major=""
+
+  if docker compose version >/dev/null 2>&1; then
+    candidate=(docker compose)
+    version="$(docker compose version --short 2>/dev/null || true)"
+    version="${version#v}"
+    major="${version%%.*}"
+    if [[ -n "$version" && ! "$major" =~ ^[0-9]+$ ]]; then
+      version=""
+    fi
+  fi
+
+  if ((${#candidate[@]} == 0)) && command -v docker-compose >/dev/null 2>&1; then
+    version="$(docker-compose version --short 2>/dev/null || true)"
+    version="${version#v}"
+    major="${version%%.*}"
+    if [[ "$major" =~ ^[0-9]+$ ]] && ((major >= 2)); then
+      candidate=(docker-compose)
+    else
+      version=""
+    fi
+  fi
+
+  if ((${#candidate[@]} == 0)); then
+    die "Docker Compose v2+ is required but not found"
+  fi
+
+  DOCKER_COMPOSE_CMD=("${candidate[@]}")
+
+  if [[ "$HOST_DNS_VERBOSE" == "1" ]]; then
+    msg "Resolved Docker Compose command: ${DOCKER_COMPOSE_CMD[*]}${version:+ (version ${version})}"
+  fi
+}
+
 parse_upstream_list() {
   local raw="$1"
   local -a parts=()
@@ -57,6 +96,8 @@ if ((${#FALLBACKS[@]} == 0)); then
 fi
 
 MODE="${DNS_DISTRIBUTION_MODE:-router}"
+
+DOCKER_COMPOSE_CMD=()
 
 # ---- Paths & backups ----
 TS="$(date +%Y%m%d-%H%M%S)"
@@ -200,7 +241,8 @@ cat "${RESOLV}"
 
 # ---- Start/Restart local_dns (dnsmasq) container ----
 msg "Starting local_dns container"
-docker compose up -d local_dns
+resolve_docker_compose_cmd
+"${DOCKER_COMPOSE_CMD[@]}" up -d local_dns
 
 msg "Verifying port 53 is bound by dnsmasq"
 if command -v ss >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add a helper in the host DNS scripts to resolve a v2-capable Docker Compose command and optionally log the selection
- switch the setup/rollback flows to use the resolved command when starting or stopping the local_dns container

## Testing
- bash -n scripts/host-dns-setup.sh
- bash -n scripts/host-dns-rollback.sh

------
https://chatgpt.com/codex/tasks/task_e_68dcd7ec5d848329b7681dcb1de36a83