### PR TITLE
fix: ensure docker directory exists before configuring DNS

### DIFF
--- a/scripts/setup-lan-dns.sh
+++ b/scripts/setup-lan-dns.sh
@@ -166,6 +166,15 @@ configure_docker_dns() {
   fi
 
   local tmp=""
+  local daemon_dir
+  daemon_dir="$(dirname "${daemon_json}")"
+
+  ensure_dir_mode "${daemon_dir}" 755
+  if [[ ! -d "${daemon_dir}" ]]; then
+    warn "Unable to prepare ${daemon_dir}; skipping Docker DNS configuration."
+    return 1
+  fi
+
   if ! tmp="$(arrstack_mktemp_file "${daemon_json}.XXXXXX" 644)"; then
     warn "Unable to create temporary file for ${daemon_json}; skipping Docker DNS configuration."
     return 1


### PR DESCRIPTION
## Summary
- ensure `configure_docker_dns` prepares `/etc/docker` before writing `daemon.json`

## Impact
- allows Docker DNS rewriting to succeed on fresh hosts where `/etc/docker` does not yet exist

## Actions
- none

## Testing
- `shellcheck scripts/setup-lan-dns.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3d94d8288329894c453655e1b783