### PR TITLE
Fix arr.config.sync helper to respect compose resolution

### DIFF
--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -47,10 +47,28 @@ write_aliases_file() {
   mv "$tmp_file" "$aliases_file"
 
   if [[ "${ENABLE_CONFIGARR:-0}" -eq 1 ]]; then
-    if ! grep -Fq "alias arr.config.sync" "$aliases_file" 2>/dev/null; then
+    if ! grep -Fq "arr.config.sync" "$aliases_file" 2>/dev/null; then
       {
         printf '\n# Configarr helper\n'
-        printf "alias arr.config.sync='docker compose run --rm configarr'\n"
+        cat <<'CONFIGARR_HELPER'
+arr.config.sync() {
+  (
+    cd "${ARR_STACK_DIR}" || return
+    local -a compose_cmd=()
+    if ((${#DOCKER_COMPOSE_CMD[@]} > 0)); then
+      compose_cmd=("${DOCKER_COMPOSE_CMD[@]}")
+    elif docker compose version >/dev/null 2>&1; then
+      compose_cmd=(docker compose)
+    elif command -v docker-compose >/dev/null 2>&1; then
+      compose_cmd=(docker-compose)
+    else
+      echo "[arr.config.sync] docker compose command not found" >&2
+      return 1
+    fi
+    "${compose_cmd[@]}" run --rm configarr
+  )
+}
+CONFIGARR_HELPER
       } >>"$aliases_file"
     fi
   fi


### PR DESCRIPTION
## Summary
- wrap the arr.config.sync helper in a subshell so it executes from ${ARR_STACK_DIR}
- invoke Configarr with the resolved DOCKER_COMPOSE_CMD when present and auto-detect docker compose/docker-compose otherwise

## Impact
- arr.config.sync now works regardless of the caller's working directory and on hosts that expose only the docker-compose CLI shim

## Actions Required
- regenerate `.aliasarr` (for example via `./arrstack.sh --refresh-aliases`) to pick up the updated helper implementation

## Testing
- shellcheck scripts/aliases.sh *(fails: shellcheck not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3e3cdb68832992b0781ac33a0dd6