### PR TITLE
Fix arr.config.sync alias to use compose wrapper

### DIFF
--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -50,7 +50,7 @@ write_aliases_file() {
     if ! grep -Fq "alias arr.config.sync" "$aliases_file" 2>/dev/null; then
       {
         printf '\n# Configarr helper\n'
-        printf "alias arr.config.sync='docker compose run --rm configarr'\n"
+        printf "alias arr.config.sync='_arr_compose run --rm configarr'\n"
       } >>"$aliases_file"
     fi
   fi


### PR DESCRIPTION
## Summary
- update the arr.config.sync alias emitted by scripts/aliases.sh to call the _arr_compose helper
- ensure the helper always executes docker compose from the stack directory regardless of cwd

## Impact
- arr.config.sync now works from any directory without manually changing into the stack folder first

## Actions for Host-User
- none

## Testing
- shellcheck scripts/aliases.sh *(fails: shellcheck: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3e8e8080832993158bbfab11513f