### PR TITLE
Fix boolean env toggles to accept string values

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -4,7 +4,7 @@
 set -Eeuo pipefail
 
 # Secure default file creation; allow opt-out for legacy setups
-if [[ "${ARRSTACK_DISABLE_UMASK:-0}" -ne 1 ]]; then
+if [[ "${ARRSTACK_DISABLE_UMASK:-0}" != "1" ]]; then
   umask 027
 fi
 
@@ -33,9 +33,9 @@ _expected_base="${ARR_BASE:-${HOME}/srv}"
 _canon_base="$(readlink -f "${_expected_base}" 2>/dev/null || printf '%s' "${_expected_base}")"
 _canon_userconf="$(readlink -f "${ARR_USERCONF_PATH}" 2>/dev/null || printf '%s' "${ARR_USERCONF_PATH}")"
 
-if [[ "${ARR_USERCONF_ALLOW_OUTSIDE:-0}" -ne 1 ]]; then
+if [[ "${ARR_USERCONF_ALLOW_OUTSIDE:-0}" != "1" ]]; then
   if [[ "${_canon_userconf}" != "${_canon_base}/userr.conf" ]]; then
-    if [[ "${ARR_USERCONF_STRICT:-0}" -eq 1 ]]; then
+    if [[ "${ARR_USERCONF_STRICT:-0}" == "1" ]]; then
       printf '[arrstack] user config path outside base (%s): %s (strict mode)\n' "${_canon_base}" "${_canon_userconf}" >&2
       exit 1
     else
@@ -52,12 +52,12 @@ fi
 ARR_USERCONF_PATH="${_canon_userconf}"
 unset _canon_userconf _canon_base _expected_base
 
-if [[ "${ARRSTACK_HARDEN_READONLY:-0}" -eq 1 ]]; then
+if [[ "${ARRSTACK_HARDEN_READONLY:-0}" == "1" ]]; then
   readonly REPO_ROOT ARR_USERCONF_PATH
 fi
 
 SCRIPT_LIB_DIR="${REPO_ROOT}/scripts"
-if [[ "${ARRSTACK_HARDEN_READONLY:-0}" -eq 1 ]]; then
+if [[ "${ARRSTACK_HARDEN_READONLY:-0}" == "1" ]]; then
   readonly SCRIPT_LIB_DIR
 fi
 modules=(
@@ -81,7 +81,7 @@ modules=(
 for module in "${modules[@]}"; do
   f="${SCRIPT_LIB_DIR}/${module}"
   if [[ ! -f "${f}" ]]; then
-    if [[ "${ARRSTACK_ALLOW_MISSING_MODULES:-0}" -eq 1 ]]; then
+    if [[ "${ARRSTACK_ALLOW_MISSING_MODULES:-0}" == "1" ]]; then
       printf '[arrstack] WARN: missing module (continuing due to ARRSTACK_ALLOW_MISSING_MODULES=1): %s\n' "${f}" >&2
       continue
     fi
@@ -170,7 +170,7 @@ main() {
     esac
   done
 
-  if [[ "${REFRESH_ALIASES:-0}" -eq 1 ]]; then
+  if [[ "${REFRESH_ALIASES:-0}" == "1" ]]; then
     refresh_aliases
     return 0
   fi
@@ -188,7 +188,7 @@ main() {
   preflight_compose_interpolation
   validate_compose_or_die
   write_gluetun_control_assets
-  if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
     ensure_caddy_auth
     write_caddy_assets
     validate_caddy_config
@@ -202,10 +202,10 @@ main() {
   if ! write_aliases_file; then
     warn "Helper aliases file could not be generated"
   fi
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" ]]; then
     configure_local_dns_entries
   fi
-  if [[ "${SETUP_HOST_DNS:-0}" -eq 1 ]]; then
+  if [[ "${SETUP_HOST_DNS:-0}" == "1" ]]; then
     run_host_dns_setup
   fi
   write_configarr_assets
@@ -218,9 +218,9 @@ main() {
   API_KEYS_SYNCED_PLACEHOLDERS=0
 
   # shellcheck disable=SC2034 # values consumed by scripts/summary.sh
-  if [[ "${FORCE_SYNC_API_KEYS:-0}" -eq 1 ]]; then
+  if [[ "${FORCE_SYNC_API_KEYS:-0}" == "1" ]]; then
     arrstack_sync_arr_api_keys 1 || true
-  elif [[ "${DISABLE_AUTO_API_KEY_SYNC:-0}" -eq 1 ]]; then
+  elif [[ "${DISABLE_AUTO_API_KEY_SYNC:-0}" == "1" ]]; then
     API_KEYS_SYNCED_STATUS="disabled"
     API_KEYS_SYNCED_MESSAGE="Configarr API key sync skipped (--no-auto-api-sync)."
     if [[ -f "${ARR_DOCKER_DIR}/configarr/secrets.yml" ]] && grep -Fq 'REPLACE_WITH_' "${ARR_DOCKER_DIR}/configarr/secrets.yml" 2>/dev/null; then
@@ -230,7 +230,7 @@ main() {
     arrstack_sync_arr_api_keys 0 || true
   fi
 
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 && "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" && "${ENABLE_CADDY:-0}" == "1" ]]; then
     local doctor_script="${REPO_ROOT}/scripts/doctor.sh"
     if [[ -x "${doctor_script}" ]]; then
       msg "🩺 Running LAN diagnostics"
@@ -248,7 +248,7 @@ main() {
     else
       warn "Doctor script missing or not executable at ${doctor_script}"
     fi
-  elif [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 ]]; then
+  elif [[ "${ENABLE_LOCAL_DNS:-0}" == "1" ]]; then
     msg "🩺 Skipping LAN diagnostics (ENABLE_CADDY=0)"
   fi
 

--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -46,7 +46,7 @@ write_aliases_file() {
 
   mv "$tmp_file" "$aliases_file"
 
-  if [[ "${ENABLE_CONFIGARR:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CONFIGARR:-0}" == "1" ]]; then
     if ! grep -Fq "alias arr.config.sync" "$aliases_file" 2>/dev/null; then
       {
         printf '\n# Configarr helper\n'

--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -47,7 +47,7 @@ write_aliases_file() {
   mv "$tmp_file" "$aliases_file"
 
   if [[ "${ENABLE_CONFIGARR:-0}" == "1" ]]; then
-    if ! grep -Fq "alias arr.config.sync" "$aliases_file" 2>/dev/null; then
+    if ! grep -Fq "arr.config.sync" "$aliases_file" 2>/dev/null; then
       {
         printf '\n# Configarr helper\n'
         cat <<'CONFIGARR_HELPER'

--- a/scripts/apikeys.sh
+++ b/scripts/apikeys.sh
@@ -151,7 +151,7 @@ arrstack_sync_arr_api_keys() {
   API_KEYS_SYNCED_DETAILS=""
   API_KEYS_SYNCED_PLACEHOLDERS=0
 
-  if [[ "${ENABLE_CONFIGARR:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_CONFIGARR:-0}" != "1" ]]; then
     API_KEYS_SYNCED_STATUS="skipped"
     API_KEYS_SYNCED_MESSAGE="Configarr disabled; API key sync skipped."
     return 0

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -211,7 +211,7 @@ ensure_dir() {
   fi
 
   local rc=$?
-  if [[ "${ARRSTACK_ALLOW_SUDO_DIRS:-0}" -eq 1 ]]; then
+  if [[ "${ARRSTACK_ALLOW_SUDO_DIRS:-0}" == "1" ]]; then
     if [[ $EUID -ne 0 ]]; then
       if command -v sudo >/dev/null 2>&1; then
         if sudo mkdir -p "$dir" 2>/dev/null || sudo mkdir -p "$dir"; then
@@ -243,7 +243,7 @@ ensure_dir_mode() {
     return 0
   fi
 
-  if [[ "${ARRSTACK_ALLOW_SUDO_DIRS:-0}" -eq 1 ]]; then
+  if [[ "${ARRSTACK_ALLOW_SUDO_DIRS:-0}" == "1" ]]; then
     if [[ $EUID -ne 0 ]]; then
       if command -v sudo >/dev/null 2>&1; then
         if sudo chmod "$mode" "$dir" 2>/dev/null; then

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -181,10 +181,10 @@ If anything looks incorrect, edit ${ARR_USERCONF_PATH} before continuing.
 CONFIG
 
   if [[ "${SPLIT_VPN:-0}" == "1" ]]; then
-    if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+    if [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
       warn "SPLIT_VPN=1: Caddy will be disabled automatically (unsupported in split mode)."
     fi
-    if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 ]]; then
+    if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" ]]; then
       warn "SPLIT_VPN=1: Local DNS will be disabled automatically (unsupported in split mode)."
     fi
   fi

--- a/scripts/dns.sh
+++ b/scripts/dns.sh
@@ -7,7 +7,7 @@ if [[ -n "${SCRIPT_LIB_DIR:-}" && -f "${SCRIPT_LIB_DIR}/network.sh" ]]; then
 fi
 # Invokes LAN DNS helper when Caddy/local DNS are enabled and host prerequisites met
 configure_local_dns_entries() {
-  if [[ "${ENABLE_CADDY:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" != "1" ]]; then
     msg "🧭 Skipping local DNS host entry helper (ENABLE_CADDY=0)"
     return 0
   fi
@@ -16,7 +16,7 @@ configure_local_dns_entries() {
 
   local helper_script="${REPO_ROOT}/scripts/setup-lan-dns.sh"
 
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -ne 1 || ${LOCAL_DNS_SERVICE_ENABLED:-0} -ne 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" != "1" || "${LOCAL_DNS_SERVICE_ENABLED:-0}" != "1" ]]; then
     msg "  Local DNS container disabled; skipping host entries helper"
     return 0
   fi
@@ -61,12 +61,12 @@ configure_local_dns_entries() {
 
 # Executes privileged host DNS takeover helper when explicitly requested
 run_host_dns_setup() {
-  if [[ "${ENABLE_CADDY:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" != "1" ]]; then
     msg "Skipping host DNS setup (--setup-host-dns) because ENABLE_CADDY=0"
     return 0
   fi
 
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" != "1" ]]; then
     msg "Skipping host DNS setup (--setup-host-dns) because ENABLE_LOCAL_DNS=0"
     return 0
   fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -209,7 +209,7 @@ check_network_security() {
 
   local -a direct_ports=("${QBT_HTTP_PORT_HOST}" "${SONARR_PORT}" "${RADARR_PORT}" "${PROWLARR_PORT}" "${BAZARR_PORT}" "${FLARESOLVERR_PORT}")
 
-  if [[ "${EXPOSE_DIRECT_PORTS}" -eq 1 ]]; then
+  if [[ "${EXPOSE_DIRECT_PORTS}" == "1" ]]; then
     if [[ -z "${LAN_IP:-}" || "${LAN_IP}" == "0.0.0.0" ]]; then
       echo "[doctor][warn] Direct ports enabled but LAN_IP is not set; they would bind to 0.0.0.0."
     else
@@ -279,7 +279,7 @@ check_network_security() {
     echo "[doctor][warn] Gluetun control API is reachable on ${gluetun_bindings[*]}; restrict it to LOCALHOST_IP=${LOCALHOST_IP}."
   fi
 
-  if [[ "${ENABLE_CADDY}" -ne 1 ]]; then
+  if [[ "${ENABLE_CADDY}" != "1" ]]; then
     local port
     for port in 80 443; do
       local -a bindings=()
@@ -295,7 +295,7 @@ check_network_security() {
 test_lan_connectivity() {
   echo "[doctor] Testing LAN accessibility..."
 
-  if [[ "${ENABLE_CADDY}" -ne 1 ]]; then
+  if [[ "${ENABLE_CADDY}" != "1" ]]; then
     echo "[doctor][info] Skipping Caddy HTTP checks (ENABLE_CADDY=0)."
     return
   fi
@@ -446,7 +446,7 @@ PROWLARR_PORT="${PROWLARR_PORT:-9696}"
 BAZARR_PORT="${BAZARR_PORT:-6767}"
 FLARESOLVERR_PORT="${FLARESOLVERR_PORT:-8191}"
 
-if [[ "${ENABLE_LOCAL_DNS}" -eq 1 ]]; then
+if [[ "${ENABLE_LOCAL_DNS}" == "1" ]]; then
   echo "[doctor] Checking if port 53 is free (or already bound):"
   if have_command ss; then
     if [[ -n "$(ss -H -lnu 'sport = :53' 2>/dev/null)" ]] || [[ -n "$(ss -H -lnt 'sport = :53' 2>/dev/null)" ]]; then
@@ -471,7 +471,7 @@ else
   echo "[doctor][info] Skipping port 53 availability check (local DNS disabled)."
 fi
 
-if [[ "${ENABLE_CADDY}" -eq 1 ]]; then
+if [[ "${ENABLE_CADDY}" == "1" ]]; then
   printf '[doctor] LAN domain suffix: %s\n' "${SUFFIX:-<unset>}"
 else
   echo "[doctor][info] Skipping LAN domain suffix reporting (ENABLE_CADDY=0)."
@@ -483,8 +483,8 @@ check_docker_dns_configuration
 
 printf '[doctor] DNS distribution mode: %s\n' "${DNS_DISTRIBUTION_MODE}"
 
-if [[ "${ENABLE_LOCAL_DNS}" -eq 1 ]]; then
-  if [[ "${LOCAL_DNS_SERVICE_ENABLED}" -eq 1 ]]; then
+if [[ "${ENABLE_LOCAL_DNS}" == "1" ]]; then
+  if [[ "${LOCAL_DNS_SERVICE_ENABLED}" == "1" ]]; then
     echo "[doctor] Local DNS container: enabled"
   else
     echo "[doctor][warn] Local DNS requested but the container is disabled."
@@ -509,7 +509,7 @@ fi
 if [[ -z "${LAN_IP}" || "${LAN_IP}" == "0.0.0.0" ]]; then
   echo "[doctor][warn] Skipping LAN port checks because LAN_IP is not set to a specific address."
 else
-  if [[ "${EXPOSE_DIRECT_PORTS}" -eq 1 ]]; then
+  if [[ "${EXPOSE_DIRECT_PORTS}" == "1" ]]; then
     report_port "qBittorrent UI" tcp "${LAN_IP}" "${QBT_HTTP_PORT_HOST}"
     report_port "Sonarr UI" tcp "${LAN_IP}" "${SONARR_PORT}"
     report_port "Radarr UI" tcp "${LAN_IP}" "${RADARR_PORT}"
@@ -520,14 +520,14 @@ else
     echo "[doctor][info] Direct LAN ports are disabled (EXPOSE_DIRECT_PORTS=0)."
   fi
 
-  if [[ "${ENABLE_CADDY}" -eq 1 ]]; then
+  if [[ "${ENABLE_CADDY}" == "1" ]]; then
     report_port "Caddy HTTP" tcp "${LAN_IP}" 80
     report_port "Caddy HTTPS" tcp "${LAN_IP}" 443
   else
     echo "[doctor][info] Skipping Caddy port checks (ENABLE_CADDY=0)."
   fi
 
-  if [[ "${ENABLE_LOCAL_DNS}" -eq 1 && "${LOCAL_DNS_SERVICE_ENABLED}" -eq 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS}" == "1" && "${LOCAL_DNS_SERVICE_ENABLED}" == "1" ]]; then
     report_port "Local DNS" udp "${LAN_IP}" 53
     report_port "Local DNS" tcp "${LAN_IP}" 53
   else
@@ -541,8 +541,8 @@ if [[ -n "${LOCALHOST_IP}" ]]; then
   report_port "Gluetun control" tcp "${LOCALHOST_IP}" "${GLUETUN_CONTROL_PORT}"
 fi
 
-if [[ "${ENABLE_LOCAL_DNS}" -eq 1 && "${LOCAL_DNS_SERVICE_ENABLED}" -eq 1 ]]; then
-  if [[ "${ENABLE_CADDY}" -ne 1 ]]; then
+if [[ "${ENABLE_LOCAL_DNS}" == "1" && "${LOCAL_DNS_SERVICE_ENABLED}" == "1" ]]; then
+  if [[ "${ENABLE_CADDY}" != "1" ]]; then
     echo "[doctor][info] Skipping LAN hostname resolution checks (ENABLE_CADDY=0)."
   else
     echo "[doctor] Testing DNS resolution of qbittorrent.${SUFFIX} via local resolver"
@@ -568,7 +568,7 @@ else
   echo "[doctor][info] DNS checks skipped: local DNS is disabled."
 fi
 
-if [[ "${ENABLE_CADDY}" -eq 1 ]]; then
+if [[ "${ENABLE_CADDY}" == "1" ]]; then
   echo "[doctor] Testing CA fetch over HTTP (bootstrap)"
   if have_command curl && have_command openssl; then
     if cert_output="$(curl -fsS "http://ca.${SUFFIX}/root.crt" 2>/dev/null | openssl x509 -noout -subject -issuer 2>/dev/null)"; then
@@ -600,7 +600,7 @@ fi
 
 test_lan_connectivity
 
-if [[ "${ENABLE_LOCAL_DNS}" -eq 1 ]]; then
+if [[ "${ENABLE_LOCAL_DNS}" == "1" ]]; then
   case "${DNS_DISTRIBUTION_MODE}" in
     router)
       echo "[doctor][info] DNS distribution mode 'router': set DHCP Option 6 (DNS server) on your router to ${LAN_IP}."
@@ -618,24 +618,24 @@ fi
 
 lan_target="${LAN_IP:-<unset>}"
 echo "[doctor] From another LAN device you can try:"
-if [[ "${EXPOSE_DIRECT_PORTS}" -eq 1 ]]; then
+if [[ "${EXPOSE_DIRECT_PORTS}" == "1" ]]; then
   echo "  curl -I http://${lan_target}:${QBT_HTTP_PORT_HOST}"
   echo "  curl -I http://${lan_target}:${SONARR_PORT}"
 else
   echo "  (Direct ports disabled; set EXPOSE_DIRECT_PORTS=1 to enable IP:PORT access.)"
 fi
 
-if [[ "${ENABLE_LOCAL_DNS}" -eq 1 && "${ENABLE_CADDY}" -eq 1 ]]; then
+if [[ "${ENABLE_LOCAL_DNS}" == "1" && "${ENABLE_CADDY}" == "1" ]]; then
   echo "  nslookup qbittorrent.${SUFFIX} ${lan_target}"
   echo "[doctor][note] If DNS queries fail:"
   echo "  - Ensure the client and ${lan_target} are on the same VLAN/subnet;"
   echo "  - Some routers block DNS to LAN hosts; allow UDP/TCP 53 to ${lan_target};"
   echo "  - Temporarily set the client DNS to ${lan_target} and retry."
-elif [[ "${ENABLE_LOCAL_DNS}" -eq 1 ]]; then
+elif [[ "${ENABLE_LOCAL_DNS}" == "1" ]]; then
   echo "  (DNS hostname troubleshooting tips skipped; ENABLE_CADDY=0.)"
 fi
 
-if [[ "${ENABLE_CADDY}" -eq 1 ]]; then
+if [[ "${ENABLE_CADDY}" == "1" ]]; then
   echo "  curl -k https://qbittorrent.${SUFFIX}/ --resolve qbittorrent.${SUFFIX}:443:${lan_target}"
 fi
 

--- a/scripts/files.sh
+++ b/scripts/files.sh
@@ -59,17 +59,17 @@ mkdirs() {
 
   local service
   for service in "${ARR_DOCKER_SERVICES[@]}"; do
-    if [[ "$service" == "local_dns" && "${ENABLE_LOCAL_DNS:-0}" -ne 1 ]]; then
+    if [[ "$service" == "local_dns" && "${ENABLE_LOCAL_DNS:-0}" != "1" ]]; then
       continue
     fi
-    if [[ "$service" == "caddy" && "${ENABLE_CADDY:-0}" -ne 1 ]]; then
+    if [[ "$service" == "caddy" && "${ENABLE_CADDY:-0}" != "1" ]]; then
       continue
     fi
     ensure_dir_mode "${ARR_DOCKER_DIR}/${service}" "$DATA_DIR_MODE"
   done
 
   local collab_enabled=0
-  if [[ "${ARR_PERMISSION_PROFILE}" == "collab" && "${COLLAB_GROUP_WRITE_ENABLED:-0}" -eq 1 ]]; then
+  if [[ "${ARR_PERMISSION_PROFILE}" == "collab" && "${COLLAB_GROUP_WRITE_ENABLED:-0}" == "1" ]]; then
     collab_enabled=1
   elif [[ "${ARR_PERMISSION_PROFILE}" == "collab" ]]; then
     arrstack_report_collab_skip
@@ -178,7 +178,7 @@ safe_random_alnum() {
 generate_api_key() {
   msg "🔐 Generating API key"
 
-  if [[ -f "$ARR_ENV_FILE" ]] && [[ "$FORCE_ROTATE_API_KEY" != 1 ]]; then
+  if [[ -f "$ARR_ENV_FILE" ]] && [[ "$FORCE_ROTATE_API_KEY" != "1" ]]; then
     local existing
     existing="$(grep '^GLUETUN_API_KEY=' "$ARR_ENV_FILE" 2>/dev/null | cut -d= -f2- || true)"
     if [[ -n "$existing" ]]; then
@@ -322,12 +322,12 @@ write_env() {
   gluetun_firewall_outbound="$(printf '%s\n' "${outbound_candidates[@]}" | sort -u | paste -sd, -)"
 
   local -a firewall_ports=()
-  if (( split_vpn == 0 )) && [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+  if (( split_vpn == 0 )) && [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
     firewall_ports+=(80 443)
   fi
   if (( split_vpn == 1 )); then
     firewall_ports+=("${QBT_HTTP_PORT_HOST}")
-  elif [[ "${EXPOSE_DIRECT_PORTS:-0}" -eq 1 ]]; then
+  elif [[ "${EXPOSE_DIRECT_PORTS:-0}" == "1" ]]; then
     firewall_ports+=("${QBT_HTTP_PORT_HOST}" "${SONARR_PORT}" "${RADARR_PORT}" "${PROWLARR_PORT}" "${BAZARR_PORT}" "${FLARESOLVERR_PORT}")
   fi
 
@@ -357,10 +357,10 @@ write_env() {
   fi
 
   local -a compose_profiles=(ipdirect)
-  if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
     compose_profiles+=(proxy)
   fi
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" ]]; then
     compose_profiles+=(localdns)
   fi
 
@@ -630,7 +630,7 @@ YAML
       - arr_net
 YAML
 
-    if [[ "${EXPOSE_DIRECT_PORTS:-0}" -eq 1 ]]; then
+    if [[ "${EXPOSE_DIRECT_PORTS:-0}" == "1" ]]; then
       cat <<'YAML' >>"$tmp"
     ports:
       - "${LAN_IP}:${SONARR_PORT}:${SONARR_PORT}"
@@ -664,7 +664,7 @@ YAML
       - arr_net
 YAML
 
-    if [[ "${EXPOSE_DIRECT_PORTS:-0}" -eq 1 ]]; then
+    if [[ "${EXPOSE_DIRECT_PORTS:-0}" == "1" ]]; then
       cat <<'YAML' >>"$tmp"
     ports:
       - "${LAN_IP}:${RADARR_PORT}:${RADARR_PORT}"
@@ -698,7 +698,7 @@ YAML
       - arr_net
 YAML
 
-    if [[ "${EXPOSE_DIRECT_PORTS:-0}" -eq 1 ]]; then
+    if [[ "${EXPOSE_DIRECT_PORTS:-0}" == "1" ]]; then
       cat <<'YAML' >>"$tmp"
     ports:
       - "${LAN_IP}:${PROWLARR_PORT}:${PROWLARR_PORT}"
@@ -729,7 +729,7 @@ YAML
       - arr_net
 YAML
 
-    if [[ "${EXPOSE_DIRECT_PORTS:-0}" -eq 1 ]]; then
+    if [[ "${EXPOSE_DIRECT_PORTS:-0}" == "1" ]]; then
       cat <<'YAML' >>"$tmp"
     ports:
       - "${LAN_IP}:${BAZARR_PORT}:${BAZARR_PORT}"
@@ -771,7 +771,7 @@ YAML
       - arr_net
 YAML
 
-    if [[ "${EXPOSE_DIRECT_PORTS:-0}" -eq 1 ]]; then
+    if [[ "${EXPOSE_DIRECT_PORTS:-0}" == "1" ]]; then
       cat <<'YAML' >>"$tmp"
     ports:
       - "${LAN_IP}:${FLARESOLVERR_PORT}:${FLARESOLVERR_PORT}"
@@ -804,7 +804,7 @@ YAML
         max-file: "2"
 YAML
 
-    if [[ "${ENABLE_CONFIGARR:-0}" -eq 1 ]]; then
+    if [[ "${ENABLE_CONFIGARR:-0}" == "1" ]]; then
       cat <<'YAML' >>"$tmp"
   configarr:
     image: ${CONFIGARR_IMAGE}
@@ -875,11 +875,11 @@ write_compose() {
 
     mapfile -t upstream_dns_servers < <(collect_upstream_dns_servers)
 
-    if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+    if [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
       include_caddy=1
     fi
 
-    if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 ]]; then
+    if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" ]]; then
       include_local_dns=1
       local_dns_state_message="Local DNS container requested"
     fi
@@ -971,7 +971,7 @@ YAML
 YAML
     fi
 
-    if [[ "${EXPOSE_DIRECT_PORTS:-0}" -eq 1 ]]; then
+    if [[ "${EXPOSE_DIRECT_PORTS:-0}" == "1" ]]; then
       cat <<'YAML' >>"$tmp"
       - "${LAN_IP}:${QBT_HTTP_PORT_HOST}:8080"
       - "${LAN_IP}:${SONARR_PORT}:${SONARR_PORT}"
@@ -1233,7 +1233,7 @@ YAML
         max-file: "2"
 YAML
 
-    if [[ "${ENABLE_CONFIGARR:-0}" -eq 1 ]]; then
+    if [[ "${ENABLE_CONFIGARR:-0}" == "1" ]]; then
       cat <<'YAML' >>"$tmp"
   configarr:
     image: ${CONFIGARR_IMAGE}
@@ -1455,7 +1455,7 @@ attempt_update() {
         fi
         cleanup_cookie
     else
-        if [ "${ATTEMPT:-0}" -eq 1 ]; then
+        if [ "${ATTEMPT:-0}" = "1" ]; then
             log "Skipping authenticated update: QBT_USER/QBT_PASS not provided"
         fi
     fi
@@ -1494,7 +1494,7 @@ HOOK
 
 # Ensures Caddy basic auth credentials exist, regenerating bcrypt/hash artifacts as needed
 ensure_caddy_auth() {
-  if [[ "${ENABLE_CADDY:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" != "1" ]]; then
     msg "🔐 Skipping Caddy Basic Auth setup (ENABLE_CADDY=0)"
     return 0
   fi
@@ -1636,7 +1636,7 @@ sync_caddy_ca_public_copy() {
 
 # Generates Caddyfile and copies CA assets when proxying is enabled
 write_caddy_assets() {
-  if [[ "${ENABLE_CADDY:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" != "1" ]]; then
     msg "🌐 Skipping Caddy configuration (ENABLE_CADDY=0)"
     return 0
   fi
@@ -1960,7 +1960,7 @@ EOF
 
 # Materializes Configarr config/secrets with sanitized policy values when enabled
 write_configarr_assets() {
-  if [[ "${ENABLE_CONFIGARR:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_CONFIGARR:-0}" != "1" ]]; then
     msg "🧾 Skipping Configarr assets (ENABLE_CONFIGARR=0)"
     return 0
   fi

--- a/scripts/migrations.sh
+++ b/scripts/migrations.sh
@@ -78,7 +78,7 @@ run_one_time_migrations() {
     unset -f ensure_env_backup || true
   fi
 
-  if [[ "${ARR_PERMISSION_PROFILE}" == "collab" && "${COLLAB_GROUP_WRITE_ENABLED:-0}" -eq 1 ]]; then
+  if [[ "${ARR_PERMISSION_PROFILE}" == "collab" && "${COLLAB_GROUP_WRITE_ENABLED:-0}" == "1" ]]; then
     local collab_marker="${ARR_DOCKER_DIR}/.arrstack-collab-v1"
     if [[ -d "${ARR_DOCKER_DIR}" && ! -e "${collab_marker}" ]]; then
       local collab_migrations=0

--- a/scripts/permissions.sh
+++ b/scripts/permissions.sh
@@ -50,7 +50,7 @@ verify_permissions() {
   local issues=0
   local collab_enabled=0
 
-  if [[ "${ARR_PERMISSION_PROFILE}" == "collab" && "${COLLAB_GROUP_WRITE_ENABLED:-0}" -eq 1 ]]; then
+  if [[ "${ARR_PERMISSION_PROFILE}" == "collab" && "${COLLAB_GROUP_WRITE_ENABLED:-0}" == "1" ]]; then
     collab_enabled=1
   fi
 
@@ -92,7 +92,7 @@ verify_permissions() {
   local service
   for service in "${ARR_DOCKER_SERVICES[@]}"; do
     if [[ "$service" == "local_dns" ]]; then
-      if [[ "${ENABLE_LOCAL_DNS:-0}" -ne 1 || ${LOCAL_DNS_SERVICE_ENABLED:-0} -ne 1 ]]; then
+      if [[ "${ENABLE_LOCAL_DNS:-0}" != "1" || "${LOCAL_DNS_SERVICE_ENABLED:-0}" != "1" ]]; then
         continue
       fi
     fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -83,7 +83,7 @@ collect_port_requirements() {
 
   _requirements_ref+=("tcp|${GLUETUN_CONTROL_PORT}|Gluetun control API|${LOCALHOST_IP:-127.0.0.1}")
 
-  if [[ "${EXPOSE_DIRECT_PORTS:-0}" -eq 1 ]]; then
+  if [[ "${EXPOSE_DIRECT_PORTS:-0}" == "1" ]]; then
     if ((lan_ip_known == 0)); then
       die "EXPOSE_DIRECT_PORTS=1 requires LAN_IP to be set to your host's private IPv4 address before installation."
     fi
@@ -111,12 +111,12 @@ collect_port_requirements() {
     _requirements_ref+=("tcp|${QBT_HTTP_PORT_HOST}|qBittorrent WebUI|${LAN_IP}")
   fi
 
-  if [[ "${ENABLE_CADDY:-0}" -eq 1 ]] && ((lan_ip_known)); then
+  if [[ "${ENABLE_CADDY:-0}" == "1" ]] && ((lan_ip_known)); then
     _requirements_ref+=("tcp|80|Caddy HTTP|${LAN_IP}")
     _requirements_ref+=("tcp|443|Caddy HTTPS|${LAN_IP}")
   fi
 
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" ]]; then
     local dns_expected="*"
     if ((lan_ip_known)); then
       dns_expected="$LAN_IP"
@@ -358,7 +358,7 @@ simple_port_check() {
 
 # Validates that local DNS prerequisites are satisfied and upstream resolvers respond
 validate_dns_configuration() {
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" != "1" ]]; then
     return
   fi
 
@@ -462,7 +462,7 @@ preflight() {
 
   show_configuration_preview
 
-  if [[ "${ASSUME_YES}" != 1 ]]; then
+  if [[ "${ASSUME_YES}" != "1" ]]; then
     local response=""
 
     warn "Continue with ProtonVPN OpenVPN setup? [y/N]: "

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -903,7 +903,7 @@ start_stack() {
       fi
     fi
 
-    if [[ "$service" == "qbittorrent" && "$service_started" == "1" ]]; then
+    if [[ "$service" == "qbittorrent" ]] && (( service_started == 1 )); then
       qb_started=1
     fi
 

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -300,7 +300,7 @@ validate_compose_or_die() {
 
 # Validates generated Caddyfile using docker image when proxying is enabled
 validate_caddy_config() {
-  if [[ "${ENABLE_CADDY:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" != "1" ]]; then
     msg "🧪 Skipping Caddy validation (ENABLE_CADDY=0)"
     return 0
   fi
@@ -389,11 +389,11 @@ validate_images() {
     FLARESOLVERR_IMAGE
   )
 
-  if [[ "${ENABLE_CONFIGARR:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CONFIGARR:-0}" == "1" ]]; then
     image_vars+=(CONFIGARR_IMAGE)
   fi
 
-  if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
     image_vars+=(CADDY_IMAGE)
   fi
 
@@ -647,10 +647,10 @@ start_vpn_auto_reconnect_if_enabled() {
 show_service_status() {
   msg "Service status summary:"
   local -a services=(gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr)
-  if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
     services+=(caddy)
   fi
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 && ${LOCAL_DNS_SERVICE_ENABLED:-0} -eq 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" && "${LOCAL_DNS_SERVICE_ENABLED:-0}" == "1" ]]; then
     services+=(local_dns)
   fi
 
@@ -676,7 +676,7 @@ show_service_status() {
 
 # Disables Docker's userland proxy to let dnsmasq bind :53 reliably
 ensure_docker_userland_proxy_disabled() {
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -ne 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" != "1" ]]; then
     return 0
   fi
 
@@ -854,10 +854,10 @@ start_stack() {
   start_vpn_auto_reconnect_if_enabled
 
   local services=()
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 && ${LOCAL_DNS_SERVICE_ENABLED:-0} -eq 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" && "${LOCAL_DNS_SERVICE_ENABLED:-0}" == "1" ]]; then
     services+=(local_dns)
   fi
-  if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
     services+=(caddy)
   fi
   services+=(qbittorrent sonarr radarr prowlarr bazarr flaresolverr)
@@ -903,7 +903,7 @@ start_stack() {
       fi
     fi
 
-    if [[ "$service" == "qbittorrent" && $service_started -eq 1 ]]; then
+    if [[ "$service" == "qbittorrent" && "$service_started" == "1" ]]; then
       qb_started=1
     fi
 
@@ -929,7 +929,7 @@ start_stack() {
     done
   fi
 
-  if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
     if ! sync_caddy_ca_public_copy --wait; then
       warn "Caddy CA root certificate is not published yet; fetch http://ca.${ARR_DOMAIN_SUFFIX_CLEAN}/root.crt after Caddy issues it."
     fi

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -38,7 +38,7 @@ reload_shell_rc() {
   [ -n "$kind" ] || kind="other"
   [ -n "$omz" ] || omz=0
 
-  if [ "$kind" = "zsh" ] && [ -n "${ZSH_VERSION:-}" ] && [ "$omz" -eq 1 ] && have_command omz; then
+  if [ "$kind" = "zsh" ] && [ -n "${ZSH_VERSION:-}" ] && [ "$omz" = "1" ] && have_command omz; then
     if omz reload; then
       return 0
     fi
@@ -46,7 +46,7 @@ reload_shell_rc() {
 
   if [ "$kind" = "zsh" ] && [ -z "${ZSH_VERSION:-}" ]; then
     warn "Detected zsh login shell but running under bash; skipping automatic zsh reload"
-    if [ "$force" -eq 1 ]; then
+    if [ "$force" = "1" ]; then
       return 0
     fi
     return 1
@@ -71,7 +71,7 @@ reload_shell_rc() {
       ;;
   esac
 
-  if [ -z "$rc" ] && [ "$kind" = "zsh" ] && [ "$omz" -eq 1 ]; then
+  if [ -z "$rc" ] && [ "$kind" = "zsh" ] && [ "$omz" = "1" ]; then
     [ -r "$HOME/.zshrc" ] && rc="$HOME/.zshrc"
   fi
 
@@ -93,25 +93,25 @@ reload_shell_rc() {
     # shellcheck disable=SC1090
     if ! . "$rc"; then
       local status=$?
-      if [ "$had_nounset" -eq 1 ]; then
+      if [ "$had_nounset" = "1" ]; then
         set -u
       fi
-      if [ "$had_errexit" -eq 1 ]; then
+      if [ "$had_errexit" = "1" ]; then
         set -e
       fi
       return $status
     fi
 
-    if [ "$had_nounset" -eq 1 ]; then
+    if [ "$had_nounset" = "1" ]; then
       set -u
     fi
-    if [ "$had_errexit" -eq 1 ]; then
+    if [ "$had_errexit" = "1" ]; then
       set -e
     fi
     return 0
   fi
 
-  if [ "$force" -eq 1 ]; then
+  if [ "$force" = "1" ]; then
     return 0
   fi
 

--- a/scripts/summary.sh
+++ b/scripts/summary.sh
@@ -80,7 +80,7 @@ QBT_INFO
     msg "$vt_summary_message"
   fi
 
-  if [[ "${EXPOSE_DIRECT_PORTS:-0}" -eq 1 ]]; then
+  if [[ "${EXPOSE_DIRECT_PORTS:-0}" == "1" ]]; then
     cat <<'DIRECT'
 Direct LAN URLs (ipdirect profile enabled):
 DIRECT
@@ -99,7 +99,7 @@ Access services from the host network (docker compose exec/port-forward) or add 
 DIRECT_DISABLED
   fi
 
-  if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CADDY:-0}" == "1" ]]; then
     local domain_suffix="${ARR_DOMAIN_SUFFIX_CLEAN}"
     cat <<CADDY_INFO
 
@@ -124,15 +124,15 @@ Access the services via the direct LAN URLs above.
 Set ENABLE_CADDY=1 in ${ARR_USERCONF_PATH} and rerun ./arrstack.sh to publish HTTPS hostnames signed by the internal CA.
 NO_CADDY
     fi
-    if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 ]]; then
+    if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" ]]; then
       cat <<'DNS_HTTP'
 Local DNS is enabled. Hostnames will resolve but continue serving plain HTTP until Caddy is enabled.
 DNS_HTTP
     fi
   fi
 
-  if [[ "${ENABLE_LOCAL_DNS:-0}" -eq 1 ]]; then
-    if [[ ${LOCAL_DNS_SERVICE_ENABLED:-0} -eq 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" == "1" ]]; then
+    if [[ "${LOCAL_DNS_SERVICE_ENABLED:-0}" == "1" ]]; then
       msg "Local DNS is enabled. Point DHCP Option 6 (or per-device DNS) at ${LAN_IP:-<unset>} so hostnames resolve."
     else
       warn "Local DNS requested but the container is disabled (port 53 conflict). Resolve the conflict and rerun."
@@ -375,7 +375,7 @@ WARNING
     done < <(printf '%s\n' "${COLLAB_PERMISSION_WARNINGS}")
   fi
 
-  if [[ "${ENABLE_CONFIGARR:-0}" -eq 1 ]]; then
+  if [[ "${ENABLE_CONFIGARR:-0}" == "1" ]]; then
     local configarr_config="${ARR_DOCKER_DIR}/configarr/config.yml"
     local configarr_secrets="${ARR_DOCKER_DIR}/configarr/secrets.yml"
     cat <<CONFIGARR
@@ -414,7 +414,7 @@ POLICY
       secrets_have_placeholders=1
     fi
 
-    if [[ "${API_KEYS_SYNCED_PLACEHOLDERS:-0}" -eq 1 || secrets_have_placeholders -eq 1 ]]; then
+    if [[ "${API_KEYS_SYNCED_PLACEHOLDERS:-0}" == "1" || "${secrets_have_placeholders}" == "1" ]]; then
       warn "Configarr secrets still contain placeholder API keys. Run ./arrstack.sh --sync-api-keys after Sonarr/Radarr/Prowlarr finish initial setup."
     fi
   fi


### PR DESCRIPTION
## Summary
- replace arithmetic comparisons on boolean environment toggles with string-based checks throughout the installer and helper scripts
- normalize related helper logic to treat "1" as enabled and any other value as disabled, preventing arithmetic evaluation of strings

## Impact
- prevents arrstack workflows from aborting under `set -u` when callers export non-numeric truthy values for boolean toggles

## Testing
- `shellcheck arrstack.sh scripts/*.sh` *(fails: shellcheck not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3d00db7c832985ae37c11d1510db