### PR TITLE
fix(aliases): use stack wrapper for config sync

### DIFF
--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -50,7 +50,7 @@ write_aliases_file() {
     if ! grep -Fq "alias arr.config.sync" "$aliases_file" 2>/dev/null; then
       {
         printf '\n# Configarr helper\n'
-        printf "alias arr.config.sync='docker compose run --rm configarr'\n"
+        printf "alias arr.config.sync='_arr_compose run --rm configarr'\n"
       } >>"$aliases_file"
     fi
   fi


### PR DESCRIPTION
## Summary
- ensure the arr.config.sync alias delegates to _arr_compose so docker compose runs from the stack directory

## Impact
- arr.config.sync succeeds regardless of the caller's working directory

## Testing
- shellcheck scripts/aliases.sh *(missing: shellcheck)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3e8e8080832993158bbfab11513f