### PR TITLE
Use positional arguments for pkexec escalation

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -439,12 +439,12 @@ arrstack_escalate_privileges() {
     if command -v bash >/dev/null 2>&1; then
       export ARRSTACK_ESCALATED=1
       # shellcheck disable=SC2093
-      exec pkexec /bin/bash -c "exec \"${_script_path}\" \"\$@\"" -- "$@"
+      exec pkexec /bin/bash -c 'exec "$@"' bash "${_script_path}" "$@"
       unset ARRSTACK_ESCALATED
     else
       export ARRSTACK_ESCALATED=1
       # shellcheck disable=SC2093
-      exec pkexec /bin/sh -c "exec \"${_script_path}\" \"\$@\"" -- "$@"
+      exec pkexec /bin/sh -c 'exec "$@"' sh "${_script_path}" "$@"
       unset ARRSTACK_ESCALATED
     fi
     return 0


### PR DESCRIPTION
## Summary
- execute pkexec through bash using positional parameters so script paths with special characters are passed verbatim
- mirror the positional-parameter strategy for the /bin/sh fallback path

## Testing
- su -s /bin/bash nobody -c /tmp/run_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68dd71f41218832990221f29122326f2