### PR TITLE
fix: tighten SABnzbd preservation and VPN defaults

### DIFF
--- a/.aliasarr
+++ b/.aliasarr
@@ -175,6 +175,9 @@ _arr_loopback() {
 }
 
 _arr_services=(gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr configarr caddy local_dns)
+if _arr_bool "${SABNZBD_ENABLED:-$(_arr_env_get SABNZBD_ENABLED)}"; then
+  _arr_services+=(sabnzbd)
+fi
 
 _arr_compose() { (cd "$ARR_STACK_DIR" && docker compose "$@" ); }
 
@@ -209,12 +212,13 @@ _arr_bool() {
 _arr_service_port() {
   local svc="$1" env_var default value
   case "$svc" in
-    qbittorrent) env_var=QBT_HTTP_PORT_HOST; default=8080 ;;
+    qbittorrent) env_var=QBT_HTTP_PORT_HOST; default=8082 ;;
     sonarr)      env_var=SONARR_PORT;        default=8989 ;;
     radarr)      env_var=RADARR_PORT;        default=7878 ;;
     prowlarr)    env_var=PROWLARR_PORT;      default=9696 ;;
     bazarr)      env_var=BAZARR_PORT;        default=6767 ;;
     flaresolverr)env_var=FLARESOLVERR_PORT;  default=8191 ;;
+    sabnzbd)     env_var=SABNZBD_PORT;       default=8080 ;;
     caddy)       env_var=CADDY_PORT;         default=80   ;;
     *)           return 1 ;;
   esac
@@ -241,7 +245,7 @@ _arr_enable_caddy() {
 }
 
 _arr_service_base() {
-  local svc="$1" enable_caddy="$(_arr_enable_caddy)"
+  local svc="$1" enable_caddy="$(_arr_enable_caddy)" host
   if [ "$svc" = "caddy" ]; then
     if [ "$enable_caddy" = "1" ]; then
       printf 'http://health.%s' "$(_arr_domain_suffix)"
@@ -253,7 +257,7 @@ _arr_service_base() {
 
   if [ "$enable_caddy" = "1" ]; then
     case "$svc" in
-      qbittorrent|sonarr|radarr|prowlarr|bazarr|flaresolverr)
+      qbittorrent|sonarr|radarr|prowlarr|bazarr|flaresolverr|sabnzbd)
         printf 'http://%s.%s' "$svc" "$(_arr_domain_suffix)"
         return
         ;;
@@ -261,8 +265,16 @@ _arr_service_base() {
   fi
 
   case "$svc" in
-    qbittorrent|sonarr|radarr|prowlarr|bazarr|flaresolverr)
-      printf 'http://%s:%s' "$(_arr_host)" "$(_arr_service_port "$svc")"
+    qbittorrent|sonarr|radarr|prowlarr|bazarr|flaresolverr|sabnzbd)
+      if [ "$svc" = "sabnzbd" ]; then
+        host="${SABNZBD_HOST:-$(_arr_env_get SABNZBD_HOST)}"
+        if [ -z "$host" ] || [ "$host" = "0.0.0.0" ]; then
+          host="$(_arr_host)"
+        fi
+      else
+        host="$(_arr_host)"
+      fi
+      printf 'http://%s:%s' "$host" "$(_arr_service_port "$svc")"
       return
       ;;
   esac

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Self-host the *arr stack with Proton VPN port forwarding on a Debian-based host.
    ./arrstack.sh --yes         # omit --yes for interactive mode
    ```
    The script installs prerequisites, renders `.env` and `docker-compose.yml`, and starts the stack. Rerun it anytime after editing `userr.conf`.
-5. **Access services.** Use the summary printed by the installer or browse to `http://LAN_IP:PORT` (for example `http://192.168.1.50:8080` for qBittorrent).
+5. **Access services.** Use the summary printed by the installer or browse to `http://LAN_IP:PORT` (for example `http://192.168.1.50:8082` for qBittorrent).
 
 ## Minimal configuration
 - `userr.conf` lives at `${ARR_BASE:-$HOME/srv}/userr.conf`; keep it outside version control.
@@ -50,7 +50,6 @@ Self-host the *arr stack with Proton VPN port forwarding on a Debian-based host.
   ```bash
   ./arrstack.sh --help
   ```
-
 ## Next steps
 - Read [Configuration](./docs/configuration.md) for variable precedence and permission profiles.
 - Follow [Networking](./docs/networking.md) before enabling split VPN, local DNS, or HTTPS.
@@ -66,15 +65,19 @@ Enable in your user config (for example `${ARR_BASE}/userr.conf`):
 
 ```bash
 SABNZBD_ENABLED=1
-SABNZBD_API_KEY=YOUR_KEY
-# Optional overrides
-SABNZBD_PORT=8780          # Host port for the WebUI (8080 used by qBittorrent)
-SABNZBD_URL="http://localhost:8780"  # Helper/API endpoint
+# Optional overrides (see docs/sabnzbd.md for the full matrix)
+SABNZBD_PORT=8080          # Host port for the WebUI (qBittorrent now defaults to 8082)
+SABNZBD_HOST="${LOCALHOST_IP}"  # Host sab-helper uses (defaults to LOCALHOST_IP)
 SABNZBD_CATEGORY="arrbash" # Category assigned to helper-submitted jobs
-SABNZBD_TIMEOUT=15         # Helper API timeout in seconds
-# Set SABNZBD_USE_VPN=1 to route via Gluetun (falls back to direct if VPN disabled)
+SABNZBD_TIMEOUT=15         # Helper/API timeout in seconds
 # Set SABNZBD_IMAGE=lscr.io/linuxserver/sabnzbd:latest to pin an alternate container tag
 ```
+
+After your first SABnzbd login, paste the API key into the WebUI once; reruns will hydrate
+`SABNZBD_API_KEY` from `sabnzbd.ini` automatically.
+
+Refer to [docs/sabnzbd.md](docs/sabnzbd.md) for networking scenarios, API key preservation,
+and helper usage tips.
 
 Run:
 

--- a/arrconf/userr.conf.defaults.sh
+++ b/arrconf/userr.conf.defaults.sh
@@ -199,18 +199,19 @@ VPN_ROTATION_MAX_PER_DAY="${VPN_ROTATION_MAX_PER_DAY:-6}"
 VPN_ROTATION_JITTER_SECONDS="${VPN_ROTATION_JITTER_SECONDS:-0}"
 
 # Service ports
-QBT_HTTP_PORT_HOST="${QBT_HTTP_PORT_HOST:-8080}"
+QBT_WEBUI_PORT="${QBT_WEBUI_PORT:-8082}"
+QBT_HTTP_PORT_HOST="${QBT_HTTP_PORT_HOST:-8082}"
 SONARR_PORT="${SONARR_PORT:-8989}"
 RADARR_PORT="${RADARR_PORT:-7878}"
 PROWLARR_PORT="${PROWLARR_PORT:-9696}"
 BAZARR_PORT="${BAZARR_PORT:-6767}"
 FLARESOLVERR_PORT="${FLARESOLVERR_PORT:-8191}"
-SABNZBD_PORT="${SABNZBD_PORT:-8780}"
+SABNZBD_PORT="${SABNZBD_PORT:-8080}"
 
 # SABnzbd integration
 SABNZBD_ENABLED="${SABNZBD_ENABLED:-0}"
 SABNZBD_USE_VPN="${SABNZBD_USE_VPN:-0}"
-SABNZBD_URL="${SABNZBD_URL:-http://localhost:8780}"
+SABNZBD_HOST="${SABNZBD_HOST:-${LOCALHOST_IP}}"
 SABNZBD_API_KEY="${SABNZBD_API_KEY:-}"
 SABNZBD_CATEGORY="${SABNZBD_CATEGORY:-arrbash}"
 SABNZBD_TIMEOUT="${SABNZBD_TIMEOUT:-15}"
@@ -311,7 +312,7 @@ ARRSTACK_USERCONF_TEMPLATE_VARS=(
   SABNZBD_PORT
   SABNZBD_ENABLED
   SABNZBD_USE_VPN
-  SABNZBD_URL
+  SABNZBD_HOST
   SABNZBD_API_KEY
   SABNZBD_CATEGORY
   SABNZBD_TIMEOUT
@@ -547,9 +548,9 @@ CADDY_BASIC_AUTH_HASH=""               # Bcrypt hash for the Basic Auth password
 
 # --- SABnzbd (Usenet downloader) ---
 SABNZBD_ENABLED="${SABNZBD_ENABLED}"             # 1 enables SABnzbd container/helper integration (default: ${SABNZBD_ENABLED})
-SABNZBD_USE_VPN="${SABNZBD_USE_VPN}"             # 1 routes SABnzbd through Gluetun, 0 keeps direct TLS (default: ${SABNZBD_USE_VPN})
-SABNZBD_URL="${SABNZBD_URL}"                 # API endpoint for SAB helper interactions (default: ${SABNZBD_URL})
-SABNZBD_API_KEY="${SABNZBD_API_KEY}"             # Populate with SAB API key once generated (blank to skip helper auth)
+SABNZBD_USE_VPN="${SABNZBD_USE_VPN}"             # 1 routes SABnzbd through Gluetun (default: ${SABNZBD_USE_VPN})
+SABNZBD_HOST="${SABNZBD_HOST}"           # Host used by sab-helper (default: ${SABNZBD_HOST})
+SABNZBD_API_KEY="${SABNZBD_API_KEY:-REPLACE_WITH_SABNZBD_API_KEY}"             # Hydrated automatically from sabnzbd.ini when available
 SABNZBD_CATEGORY="${SABNZBD_CATEGORY}"           # Category applied to helper-submitted jobs (default: ${SABNZBD_CATEGORY})
 SABNZBD_TIMEOUT="${SABNZBD_TIMEOUT}"             # Helper API timeout in seconds (default: ${SABNZBD_TIMEOUT})
 SABNZBD_PORT="${SABNZBD_PORT}"                 # Host port for SAB WebUI when direct (default: ${SABNZBD_PORT})

--- a/arrconf/userr.conf.example
+++ b/arrconf/userr.conf.example
@@ -67,16 +67,17 @@ CADDY_BASIC_AUTH_HASH=""               # Bcrypt hash for the Basic Auth password
 
 # --- SABnzbd (Usenet downloader) ---
 SABNZBD_ENABLED="0"             # 1 enables SABnzbd container/helper integration (default: 0)
-SABNZBD_USE_VPN="0"             # 1 routes SABnzbd through Gluetun, 0 keeps direct TLS (default: 0)
-SABNZBD_URL="http://localhost:8780"                 # API endpoint for SAB helper interactions (default: http://localhost:8780)
-SABNZBD_API_KEY=""             # Populate with SAB API key once generated (blank to skip helper auth)
+SABNZBD_USE_VPN="0"             # 1 routes SABnzbd through Gluetun (default: 0)
+SABNZBD_HOST="${LOCALHOST_IP}"                       # Host sab-helper uses (default: LOCALHOST_IP value)
+SABNZBD_API_KEY="REPLACE_WITH_SABNZBD_API_KEY"             # Populated automatically from sabnzbd.ini when available
 SABNZBD_CATEGORY="arrbash"           # Category applied to helper-submitted jobs (default: arrbash)
 SABNZBD_TIMEOUT="15"             # Helper API timeout in seconds (default: 15)
-SABNZBD_PORT="8780"                 # Host port for SAB WebUI when direct (default: 8780)
+SABNZBD_PORT="8080"                 # Host port for SAB WebUI when direct (default: 8080)
 ARRBASH_USENET_CLIENT="sabnzbd" # Active Usenet client label (future abstraction)
 
 # --- Service ports ---
-QBT_HTTP_PORT_HOST="8080"              # qBittorrent WebUI port exposed on the LAN (default: 8080)
+QBT_WEBUI_PORT="8082"                  # qBittorrent WebUI port inside the container (default: 8082)
+QBT_HTTP_PORT_HOST="8082"              # qBittorrent WebUI port exposed on the LAN (default: 8082)
 SONARR_PORT="8989"                     # Sonarr WebUI port exposed on the LAN (default: 8989)
 RADARR_PORT="7878"                     # Radarr WebUI port exposed on the LAN (default: 7878)
 PROWLARR_PORT="9696"                   # Prowlarr WebUI port exposed on the LAN (default: 9696)

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -177,6 +177,12 @@ main() {
 
   init_logging
 
+  # Pre-hydrate preserved configuration so preflight checks reflect the
+  # ports and credentials we intend to reuse during this run.
+  hydrate_qbt_host_port_from_env_file
+  hydrate_qbt_webui_port_from_config
+  hydrate_sab_api_key_from_config
+
   preflight
   check_network_requirements
   mkdirs
@@ -237,6 +243,8 @@ main() {
     local doctor_script="${REPO_ROOT}/scripts/doctor.sh"
     if [[ -x "${doctor_script}" ]]; then
       msg "🩺 Running LAN diagnostics"
+      export ARRSTACK_INTERNAL_PORT_CONFLICTS="${ARRSTACK_INTERNAL_PORT_CONFLICTS:-0}"
+      export ARRSTACK_INTERNAL_PORT_CONFLICT_DETAIL="${ARRSTACK_INTERNAL_PORT_CONFLICT_DETAIL:-}"
       if ! LAN_DOMAIN_SUFFIX="${LAN_DOMAIN_SUFFIX}" \
         LAN_IP="${LAN_IP}" \
         ENABLE_LOCAL_DNS="${ENABLE_LOCAL_DNS}" \

--- a/dev/test_sab_compose.sh
+++ b/dev/test_sab_compose.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+run_case() {
+  local name="$1"
+  shift
+  local -a overrides=("$@")
+  local tmp
+  local loop_host="localhost"
+  local qbt_port="8082"
+  tmp="$(mktemp -d)"
+  local stack_dir="${tmp}/stack"
+  local docker_dir="${tmp}/docker"
+  mkdir -p "$stack_dir" "$docker_dir"
+
+  local status=0
+  (
+    set -Eeuo pipefail
+    ARR_STACK_DIR="$stack_dir"
+    ARR_DOCKER_DIR="$docker_dir"
+    ARR_ENV_FILE="$stack_dir/.env"
+    ARRSTACK_NO_MAIN=1
+    source "${REPO_ROOT}/arrstack.sh"
+
+    PUID=1000
+    PGID=1000
+    TIMEZONE="UTC"
+    LAN_IP="192.168.0.2"
+    LOCALHOST_IP="$loop_host"
+    EXPOSE_DIRECT_PORTS=0
+    SPLIT_VPN=0
+    SABNZBD_ENABLED=1
+    SABNZBD_USE_VPN=0
+    ARRCONF_DIR="${tmp}/arrconf"
+    mkdir -p "$ARRCONF_DIR"
+    printf 'PROTON_USER=testuser\nPROTON_PASS=testpass\n' >"${ARRCONF_DIR}/proton.auth"
+    for expr in "${overrides[@]}"; do
+      eval "$expr"
+    done
+
+    write_env
+    write_compose
+    printf '%s\n' "$LAN_IP" >"${tmp}/lan_ip"
+    printf '%s\n' "${SABNZBD_PORT:-8080}" >"${tmp}/sab_port"
+  ) || status=$?
+
+  local compose_file="${stack_dir}/docker-compose.yml"
+  local env_file="${stack_dir}/.env"
+  local lan_ip=""
+  local sab_port=""
+  if [[ -f "${tmp}/lan_ip" ]]; then
+    lan_ip="$(<"${tmp}/lan_ip")"
+  fi
+  if [[ -f "${tmp}/sab_port" ]]; then
+    sab_port="$(<"${tmp}/sab_port")"
+  fi
+  if (( status != 0 )) || [[ ! -f "$compose_file" ]]; then
+    echo "[${name}] compose generation failed" >&2
+    status=1
+  else
+    if [[ $(grep -c '^  sabnzbd:' "$compose_file") -ne 1 ]]; then
+      echo "[${name}] unexpected sabnzbd block count" >&2
+      status=1
+    fi
+    if grep -q 'aliases:' "$compose_file"; then
+      echo "[${name}] unexpected network alias block" >&2
+      status=1
+    fi
+    if ! grep -q 'start_period:' "$compose_file"; then
+      echo "[${name}] sabnzbd healthcheck missing start_period" >&2
+      status=1
+    fi
+    if grep -q 'apikey=' "$compose_file"; then
+      echo "[${name}] sabnzbd healthcheck still references apikey" >&2
+      status=1
+    fi
+    if grep -q 'network_mode: "service:gluetun"' "$compose_file"; then
+      if [[ -n "$lan_ip" && -n "$sab_port" ]] && grep -q "${lan_ip}:${sab_port}:8080" "$compose_file"; then
+        echo "[${name}] found host port mapping while sharing gluetun" >&2
+        status=1
+      fi
+    fi
+    local qbt_health_literal='http://${LOCALHOST_IP}:${QBT_WEBUI_PORT}/api/v2/app/version'
+    if grep -q "http://${loop_host}:8080/api/v2/app/version" "$compose_file"; then
+      echo "[${name}] qBittorrent healthcheck still uses 8080" >&2
+      status=1
+    fi
+    if ! grep -q "$qbt_health_literal" "$compose_file"; then
+      echo "[${name}] qBittorrent healthcheck missing LOCALHOST_IP placeholder" >&2
+      status=1
+    fi
+  fi
+
+  if [[ -f "$env_file" ]]; then
+    qbt_port="$(grep -E '^QBT_WEBUI_PORT=' "$env_file" | head -n1 | cut -d= -f2- || printf '8082')"
+    if ! grep -q '^QBT_WEBUI_PORT=8082' "$env_file"; then
+      echo "[${name}] expected QBT_WEBUI_PORT=8082 in .env" >&2
+      status=1
+    fi
+    if grep -q '^FORCE_SAB_VPN=' "$env_file"; then
+      echo "[${name}] .env still contains FORCE_SAB_VPN" >&2
+      status=1
+    fi
+  fi
+
+  rm -rf "$tmp"
+  return "$status"
+}
+
+main() {
+  local -a cases=(
+    "default:SPLIT_VPN=0"
+    "default_expose:SPLIT_VPN=0 EXPOSE_DIRECT_PORTS=1"
+    "split:SPLIT_VPN=1"
+    "split_expose:SPLIT_VPN=1 EXPOSE_DIRECT_PORTS=1"
+    "vpn_enabled:SPLIT_VPN=0 SABNZBD_USE_VPN=1"
+  )
+
+  local rc=0
+  local entry
+  for entry in "${cases[@]}"; do
+    local name="${entry%%:*}"
+    local exprs_string="${entry#*:}"
+    IFS=' ' read -r -a exprs <<<"${exprs_string}"
+    if run_case "$name" "${exprs[@]}"; then
+      printf '[%s] OK\n' "$name"
+    else
+      printf '[%s] FAIL\n' "$name" >&2
+      rc=1
+    fi
+  done
+  return "$rc"
+}
+
+main "$@"

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -17,7 +17,8 @@ Use these controls to choose how traffic flows, manage Proton VPN forwarding, an
    ```bash
    ./arrstack.sh --yes
    ```
-4. Update each *Arr download client entry to point at `http://LAN_IP:${QBT_HTTP_PORT_HOST}` when running split tunnel.
+4. Update each *Arr download client entry to point at `http://LAN_IP:${QBT_HTTP_PORT_HOST}` when running split tunnel (the
+   host defaults to port **8082** unless you preserved a legacy value).
 
 Revert by setting `SPLIT_VPN=0` and rerunning the installer.
 

--- a/docs/sabnzbd.md
+++ b/docs/sabnzbd.md
@@ -1,0 +1,110 @@
+# SABnzbd Integration
+
+This document expands on the optional SABnzbd support shipped with arrbash. It covers
+networking behaviour, environment overrides, helper tooling, and the preservation
+logic that keeps your API key and configuration safe across reruns.
+
+## Network Modes
+
+| Mode | `SABNZBD_USE_VPN` | Network namespace | Host port exposure | Notes |
+| ---- | ----------------- | ----------------- | ------------------ | ----- |
+| Direct (default) | `0` | `arr_net` (split VPN) or default bridge | Controlled by `EXPOSE_DIRECT_PORTS` / `SABNZBD_PORT` | Keeps SAB reachable by the *Arr containers. |
+| Split-VPN direct | `0` | `arr_net` | Optional host mapping | Matches downloader connectivity expected by Sonarr/Radarr while qBittorrent remains tunneled. |
+| VPN (opt-in) | `1` | Gluetun (`network_mode: "service:gluetun"`) | No host ports (shares Gluetun stack) | Use only when SAB must egress via the VPN. |
+
+qBittorrent defaults to WebUI port **8082**, leaving port 8080 available for
+SABnzbd when both containers share Gluetun. If you intentionally keep SAB in
+VPN mode, keep its listen port at 8080 (qBittorrent continues to use 8082
+inside Gluetun).
+
+## API Key Preservation
+
+The preservation layer parses `${ARR_DOCKER_DIR}/sab/config/sabnzbd.ini` on reruns.
+When `api_key = ...` is present and `.env` still contains the
+`REPLACE_WITH_SABNZBD_API_KEY` placeholder, arrbash:
+
+1. Takes a timestamped backup of `sabnzbd.ini` (`sabnzbd.ini.bak-YYYYmmdd-HHMMSS`).
+2. Hydrates `SABNZBD_API_KEY` in-memory and records a preservation note for the
+   summary output.
+3. Writes the hydrated value back to `.env`, matching the qBittorrent credential
+   behaviour.
+
+When Configarr is enabled, the installer also ensures the `configarr/secrets.yml`
+file contains a `SABNZBD_API_KEY` entry. Hydrated keys replace the
+`REPLACE_WITH_SABNZBD_API_KEY` placeholder automatically; existing non-placeholder
+values are left untouched.
+
+If you manually rotate the API key, rerun `./arrstack.sh --yes` after SAB has
+written the change; the installer will detect and capture the new value.
+
+## Healthcheck Improvements
+
+The compose generator now emits a simple JSON version probe that does **not**
+require an API key:
+
+```
+http://${LOCALHOST_IP}:<internal_port>/api?mode=version&output=json
+```
+
+A `start_period` of at least 60 seconds (or your configured `SABNZBD_TIMEOUT` if
+higher) gives SAB time to bootstrap before health retries begin. The healthcheck
+message inside `scripts/services.sh` has been updated accordingly.
+
+## Configuration Overrides
+
+Relevant environment variables:
+
+- `SABNZBD_ENABLED` — enable/disable the service.
+- `SABNZBD_USE_VPN` — route SABnzbd through Gluetun (`0` keeps it on arr_net).
+- `SABNZBD_PORT` — host port when SAB runs directly on the LAN (default `8080`).
+- `SABNZBD_HOST` — hostname sab-helper targets (default `${LOCALHOST_IP}`).
+- `SABNZBD_TIMEOUT` — helper timeout *and* minimum healthcheck start period.
+- `SABNZBD_CATEGORY` — optional category applied by `sab-helper.sh add-*` commands.
+- `SABNZBD_IMAGE` — override the container image tag.
+
+Example snippet for a VPN opt-in lab environment:
+
+```bash
+SABNZBD_ENABLED=1
+SABNZBD_USE_VPN=1
+EXPOSE_DIRECT_PORTS=0
+SABNZBD_HOST="sabnzbd"     # qBittorrent now listens on 8082 inside Gluetun
+```
+
+> **Tip:** When forcing SAB through Gluetun, keep its listen port at 8080 or pick
+> another value that does not clash with your qBittorrent container port.
+
+> **Caddy note:** When SAB runs directly on the LAN (`SABNZBD_USE_VPN=0`) and
+> you enable the Caddy reverse proxy, arrbash publishes
+> `https://sabnzbd.${LAN_DOMAIN_SUFFIX}` automatically. VPN mode skips LAN port
+> exposure, so you must access SAB through Gluetun in that configuration.
+
+## Helper Script
+
+`scripts/sab-helper.sh` ships with the stack and is automatically copied to
+`${ARR_STACK_DIR}/scripts/sab-helper.sh` when SAB is enabled. Core commands:
+
+```bash
+./scripts/sab-helper.sh version   # Prints SAB version via the public API endpoint
+./scripts/sab-helper.sh status    # Summarises queue state and download speed
+./scripts/sab-helper.sh queue     # Raw queue JSON (requires API key)
+./scripts/sab-helper.sh add-file <path/to/file.nzb>
+./scripts/sab-helper.sh add-url <https://example/nzb>
+```
+
+After `./arrstack.sh --refresh-aliases`, the shell also exposes `sab-logs`,
+`sab-shell`, and `open-sab` convenience aliases.
+
+If SAB is disabled the helper prints a warning and exits gracefully. Ensure
+`SABNZBD_HOST`, `SABNZBD_PORT`, and `SABNZBD_API_KEY` are correct before using upload commands.
+The helper will still report the SAB version even when the API key is not yet
+configured, aligning with the new compose healthcheck.
+
+## Deferred Features
+
+`SABNZBD_CATEGORY` is passed through to helper uploads today but the stack does
+not yet manage SAB categories automatically. Future hardening work will also look
+at container resource limits (CPU, memory) and read-only filesystems; the compose
+output includes a commented NOTE as a reminder.
+
+For troubleshooting tips or examples, visit the main [Operations guide](operations.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,7 +20,7 @@ Keep the deployment private to your LAN and rotate credentials regularly.
 - When local DNS is enabled, ensure only trusted clients point at the Pi. Keep a fallback public resolver in DHCP to avoid outages if the Pi is offline.
 - Verify open ports regularly:
   ```bash
-  sudo ss -tulpn | grep -E ':8080|:8989|:7878|:9696|:6767|:8191|:80|:443|:53'
+  sudo ss -tulpn | grep -E ':8082|:8989|:7878|:9696|:6767|:8191|:80|:443|:53'
   ```
   Expect 80/443 only when Caddy is enabled and 53 only when local DNS is active.
 

--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -138,6 +138,27 @@ EOF
 }
 SAB_ALIAS_FUNCS
       } >>"$aliases_file"
+      {
+        printf '\n# SABnzbd shortcuts\n'
+        cat <<'SAB_SHORTCUTS'
+sab-logs() { arr.logs sabnzbd "$@"; }
+sab-shell() { arr.shell sabnzbd "$@"; }
+open-sab() {
+  local base
+  base="$(_arr_service_base sabnzbd)"
+  if [ -z "$base" ]; then
+    echo "[open-sab] unable to resolve SABnzbd base URL" >&2
+    return 1
+  fi
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$base" >/dev/null 2>&1 &
+    disown || true
+  else
+    printf '%s\n' "$base"
+  fi
+}
+SAB_SHORTCUTS
+      } >>"$aliases_file"
     fi
   fi
 

--- a/scripts/apikeys.sh
+++ b/scripts/apikeys.sh
@@ -96,6 +96,7 @@ arrstack_update_secret_line() {
 
   local line_no="${existing_line%%:*}"
   local raw_value="${existing_line#*:}"
+  raw_value="${raw_value#${secret_key}:}"
 
   raw_value="${raw_value#"${raw_value%%[![:space:]]*}"}"
   raw_value="${raw_value%%#*}"

--- a/scripts/preserve.sh
+++ b/scripts/preserve.sh
@@ -15,6 +15,109 @@ arrstack_record_preserve_note() {
   fi
 }
 
+# Hydrates SABNZBD_API_KEY from sabnzbd.ini when available so reruns keep API access
+hydrate_sab_api_key_from_config() {
+  if [[ "${SABNZBD_ENABLED:-0}" != "1" ]]; then
+    return 0
+  fi
+
+  local config_dir="${ARR_DOCKER_DIR:-${ARR_STACK_DIR}/docker-data}/sab/config"
+  local ini_path="${config_dir}/sabnzbd.ini"
+
+  if [[ -d "$config_dir" && "${ARRSTACK_SAB_CONFIG_PRESERVED:-0}" != "1" ]]; then
+    ARRSTACK_SAB_CONFIG_PRESERVED=1
+    arrstack_record_preserve_note "Preserved existing SABnzbd config at ${config_dir}" || true
+  fi
+
+  if [[ ! -f "$ini_path" ]]; then
+    return 0
+  fi
+
+  local api_key_line api_key_value
+  api_key_line="$(grep -i '^[[:space:]]*api_key[[:space:]]*=' "$ini_path" | tail -n1 || printf '')"
+  if [[ -z "$api_key_line" ]]; then
+    return 0
+  fi
+
+  api_key_value="${api_key_line#*=}"
+  api_key_value="${api_key_value#${api_key_value%%[![:space:]]*}}"
+  api_key_value="${api_key_value%${api_key_value##*[![:space:]]}}"
+
+  if [[ -z "$api_key_value" ]]; then
+    return 0
+  fi
+
+  local current_value="${SABNZBD_API_KEY:-}" placeholder=0
+  if [[ -z "$current_value" ]]; then
+    placeholder=1
+  else
+    local upper="${current_value^^}"
+    if [[ "$upper" == REPLACE_WITH_* ]]; then
+      placeholder=1
+    fi
+  fi
+
+  if ((placeholder)) && [[ "$current_value" != "$api_key_value" ]]; then
+    if [[ -z "${ARRSTACK_SAB_INI_BACKUP:-}" ]]; then
+      local timestamp backup_path
+      timestamp="$(date +%Y%m%d-%H%M%S)"
+      backup_path="${ini_path}.bak.${timestamp}"
+      if cp -a "$ini_path" "$backup_path" 2>/dev/null; then
+        ARRSTACK_SAB_INI_BACKUP="$backup_path"
+        arrstack_record_preserve_note "Backed up sabnzbd.ini to ${backup_path##*/}"
+      fi
+    fi
+
+    SABNZBD_API_KEY="$api_key_value"
+    arrstack_record_preserve_note "Hydrated SABnzbd API key from sabnzbd.ini"
+    ARRSTACK_SAB_API_KEY_SOURCE="hydrated"
+  fi
+
+  return 0
+}
+
+# Captures an existing qBittorrent WebUI host port from .env so we only migrate
+# when explicitly requested.
+hydrate_qbt_host_port_from_env_file() {
+  if [[ -z "${ARR_ENV_FILE:-}" || ! -f "$ARR_ENV_FILE" ]]; then
+    return 0
+  fi
+
+  local existing_host_port=""
+  existing_host_port="$(get_env_kv "QBT_HTTP_PORT_HOST" "$ARR_ENV_FILE" 2>/dev/null || printf '')"
+
+  if [[ -n "$existing_host_port" ]]; then
+    local trimmed="${existing_host_port//[[:space:]]/}"
+    if [[ "$trimmed" =~ ^[0-9]+$ ]]; then
+      ARRSTACK_QBT_HOST_PORT_ENV="$trimmed"
+    fi
+  fi
+}
+
+# Reads qBittorrent's configured WebUI port so compose generation honors
+# existing deployments that override the default port.
+hydrate_qbt_webui_port_from_config() {
+  local config_dir="${ARR_DOCKER_DIR:-${ARR_STACK_DIR}/docker-data}/qbittorrent"
+  local primary_conf="${config_dir}/qBittorrent.conf"
+  local legacy_conf="${config_dir}/qBittorrent/qBittorrent.conf"
+  local candidate=""
+
+  if [[ -f "$primary_conf" ]]; then
+    candidate="$primary_conf"
+  elif [[ -f "$legacy_conf" ]]; then
+    candidate="$legacy_conf"
+  else
+    return 0
+  fi
+
+  local configured_port=""
+  configured_port="$(grep -E '^WebUI\\\\Port=' "$candidate" | tail -n1 | cut -d= -f2 | tr -d '[:space:]' || printf '')"
+
+  if [[ -n "$configured_port" && "$configured_port" =~ ^[0-9]+$ ]]; then
+    ARRSTACK_QBT_WEBUI_PORT_CONFIG="$configured_port"
+  fi
+}
+
 # Pulls existing qBittorrent credentials from .env to avoid unintended resets
 hydrate_user_credentials_from_env_file() {
   if [[ -z "${ARR_ENV_FILE:-}" || ! -f "$ARR_ENV_FILE" ]]; then

--- a/scripts/sab-helper.sh
+++ b/scripts/sab-helper.sh
@@ -87,11 +87,6 @@ sab_check_env() {
     return 1
   fi
 
-  if [[ -z "${SABNZBD_URL:-}" ]]; then
-    log_error "[sab] SABNZBD_URL is not configured"
-    return 1
-  fi
-
   if ! command -v curl >/dev/null 2>&1; then
     log_error "[sab] curl is required"
     return 1
@@ -106,13 +101,35 @@ sab_check_env() {
     timeout=15
   fi
   SABNZBD_TIMEOUT="$timeout"
-  SABNZBD_PORT="${SABNZBD_PORT:-8780}"
 
+  local sab_port="${SABNZBD_PORT:-8080}"
+  if [[ ! "$sab_port" =~ ^[0-9]+$ ]]; then
+    sab_port=8080
+  fi
+  SABNZBD_PORT="$sab_port"
+
+  local sab_host="${SABNZBD_HOST:-${LOCALHOST_IP:-localhost}}"
+  if [[ -z "$sab_host" ]]; then
+    sab_host="${LOCALHOST_IP:-localhost}"
+  fi
+  SABNZBD_HOST="$sab_host"
+
+  local sab_helper_scheme="${SABNZBD_HELPER_SCHEME:-http}"
+  if [[ -z "$sab_helper_scheme" ]]; then
+    sab_helper_scheme="http"
+  fi
+  SABNZBD_HELPER_SCHEME="$sab_helper_scheme"
+
+  SAB_HELPER_ENV_READY=1
   return 0
 }
 
 sab_base_url() {
-  printf '%s' "${SABNZBD_URL:-http://localhost:8780}" | sed 's#[[:space:]]##g' | sed 's#/*$##'
+  sab_check_env || return 1
+  local scheme="${SABNZBD_HELPER_SCHEME:-http}"
+  local host="${SABNZBD_HOST:-${LOCALHOST_IP:-localhost}}"
+  local port="${SABNZBD_PORT:-8080}"
+  printf '%s://%s:%s' "$scheme" "$host" "$port" | sed 's#[[:space:]]##g' | sed 's#/*$##'
 }
 
 sab_api() {
@@ -150,10 +167,24 @@ sab_api() {
 }
 
 sab_version() {
-  local output
-  if ! output="$(sab_api 'mode=version&output=json')"; then
-    return 1
+  if [[ "${SAB_HELPER_ENV_READY:-0}" != "1" ]]; then
+    sab_check_env || return 1
   fi
+
+  local timeout="${SABNZBD_TIMEOUT:-15}"
+  local base="$(sab_base_url)"
+  local output=""
+
+  if ! output=$(curl -fsSL --connect-timeout "$timeout" "${base}/api" --get --data-urlencode 'mode=version' --data-urlencode 'output=json' 2>/dev/null); then
+    if [[ -n "${SABNZBD_API_KEY:-}" ]]; then
+      if ! output="$(sab_api 'mode=version&output=json')"; then
+        return 1
+      fi
+    else
+      return 1
+    fi
+  fi
+
   local version=""
   if command -v jq >/dev/null 2>&1; then
     version="$(jq -r '.version // empty' <<<"$output" 2>/dev/null || printf '')"

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -255,7 +255,7 @@ service_health_sabnzbd() {
   if version="$($helper version 2>/dev/null)"; then
     msg "[sabnzbd] API reachable (${version})"
   else
-    warn "[sabnzbd] Health check failed (verify SABNZBD_URL/API key)"
+    warn "[sabnzbd] Health check failed (verify SABNZBD_HOST/SABNZBD_PORT or container status)"
   fi
 }
 

--- a/scripts/vpn-auto-reconnect.sh
+++ b/scripts/vpn-auto-reconnect.sh
@@ -996,7 +996,7 @@ vpn_auto_reconnect_ensure_fresh_session() {
 
 # Fetches current transfer metrics from qBittorrent API with auth retry logic
 vpn_auto_reconnect_fetch_transfer_info() {
-  local base="${QBITTORRENT_ADDR:-http://127.0.0.1:8080}"
+  local base="${QBITTORRENT_ADDR:-http://127.0.0.1:8082}"
   local url="${base%/}/api/v2/transfer/info"
   local cookie
   cookie="$(vpn_auto_reconnect_cookie_file)"
@@ -1018,7 +1018,7 @@ vpn_auto_reconnect_fetch_transfer_info() {
 
 # Logs into qBittorrent WebUI API storing session cookie for subsequent calls
 vpn_auto_reconnect_login_qbt() {
-  local base="${QBITTORRENT_ADDR:-http://127.0.0.1:8080}"
+  local base="${QBITTORRENT_ADDR:-http://127.0.0.1:8082}"
   local url="${base%/}/api/v2/auth/login"
   local cookie
   cookie="$(vpn_auto_reconnect_cookie_file)"
@@ -1033,7 +1033,7 @@ vpn_auto_reconnect_login_qbt() {
 
 # Classifies torrent activity level to avoid reconnects during active transfers
 vpn_auto_reconnect_detect_activity() {
-  local base="${QBITTORRENT_ADDR:-http://127.0.0.1:8080}"
+  local base="${QBITTORRENT_ADDR:-http://127.0.0.1:8082}"
   local cookie
   cookie="$(vpn_auto_reconnect_cookie_file)"
   ensure_dir_mode "$(dirname -- "$cookie")" "$DATA_DIR_MODE"


### PR DESCRIPTION
## Summary
- only back up sabnzbd.ini when the API key is actually hydrated so repeated runs do not create redundant files
- automatically flip SABNZBD_HOST to sabnzbd when VPN mode is enabled, surfacing an explicit warning if a custom host remains, and note the auto state in the summary output
- pin the SAB healthcheck to 127.0.0.1 inside the container and update the port-conflict guidance to drop references to the removed migration flags

## Testing
- `bash dev/test_sab_compose.sh`


------
https://chatgpt.com/codex/tasks/task_e_68df4dfc4658832996186f966321815d