### PR TITLE
fix(scripts): source shared helpers in fix-versions

### DIFF
--- a/scripts/fix-versions.sh
+++ b/scripts/fix-versions.sh
@@ -2,16 +2,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-STACK_DIR_DEFAULT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-STACK_DIR="${ARR_STACK_DIR:-${STACK_DIR_DEFAULT}}"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/common.sh
+. "${REPO_ROOT}/scripts/common.sh"
+
+STACK_DIR="${ARR_STACK_DIR:-${REPO_ROOT}}"
 if ! STACK_DIR="$(cd "${STACK_DIR}" 2>/dev/null && pwd)"; then
-  echo "Stack directory not found: ${ARR_STACK_DIR:-${STACK_DIR_DEFAULT}}" >&2
+  echo "Stack directory not found: ${ARR_STACK_DIR:-${REPO_ROOT}}" >&2
   exit 1
 fi
 ENV_FILE="${ARR_ENV_FILE:-${STACK_DIR}/.env}"
-
-# shellcheck source=scripts/common.sh
-. "${STACK_DIR}/scripts/common.sh"
 
 if [[ ! -f "$ENV_FILE" ]]; then
   die ".env file not found at $ENV_FILE"


### PR DESCRIPTION
## Summary
- update scripts/fix-versions.sh to always source the repository's shared helpers
- keep ARR_STACK_DIR support for locating the .env file while reusing the full helper library

## Testing
- `shellcheck scripts/fix-versions.sh` *(fails: shellcheck not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08e1894e483298c756ff5e634d66b