### PR TITLE
Preserve environment overrides during config load

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -68,17 +68,10 @@ unset __arrstack_env_guard_var
 unset ARRSTACK_ENV_SNAPSHOT
 
 if [[ -f "${_canon_userconf}" ]]; then
-  trap - ERR
-  set +e
   # shellcheck source=/dev/null
-  . "${_canon_userconf}"
-  __arrstack_userconf_rc=$?
-  set -e
-  trap 'arrstack_err_trap' ERR
-  if (( __arrstack_userconf_rc != 0 )); then
-    printf '[arrstack] WARN: user configuration returned %s (see messages above for details)\n' "${__arrstack_userconf_rc}" >&2
+  if ! . "${_canon_userconf}"; then
+    printf '[arrstack] WARN: user configuration failed to source (see messages above for details)\n' >&2
   fi
-  unset __arrstack_userconf_rc
 fi
 
 unset _canon_userconf _canon_base _expected_base

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,12 +2,13 @@
 
 # Configuration guide
 
-Edit `${ARR_BASE:-$HOME/srv}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and supporting files. `./arrstack.sh` loads environment variables first, then your overrides, and finally the shipped defaults so the last writer wins.
+Edit `${ARR_BASE:-$HOME/srv}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and supporting files. `./arrstack.sh` now honors exported environment variables before reading `userr.conf`, applies CLI flags afterwards, and falls back to the shipped defaults for everything else.
 
 ## Configuration layers
-1. **Shell environment** – anything exported before running `./arrstack.sh` overrides the other sources (use for CI or one-off toggles).
-2. **`${ARR_BASE}/userr.conf`** – your persistent copy (defaults to `~/srv/userr.conf`). Keep it out of version control and rerun the installer after every edit.
-3. **`arrconf/userr.conf.defaults.sh`** – project defaults committed in the repo.
+1. **Shell environment** – anything exported before running `./arrstack.sh` wins over every other source (ideal for CI or temporary overrides). Those values are locked so `userr.conf` cannot replace them.
+2. **CLI flags** – options such as `./arrstack.sh --enable-caddy` apply after `userr.conf` for run-scoped toggles. Use them when you want a temporary change without touching your config file (or when an environment export is not already pinning the value).
+3. **`${ARR_BASE}/userr.conf`** – your persistent copy (defaults to `~/srv/userr.conf`). Keep it out of version control and rerun the installer after every edit.
+4. **`arrconf/userr.conf.defaults.sh`** – project defaults committed in the repo.
 
 The installer prints a configuration table during preflight. Cancel with `Ctrl+C` if a value looks wrong, adjust `userr.conf`, and rerun.
 

--- a/scripts/dev/verify-env-override-guard.sh
+++ b/scripts/dev/verify-env-override-guard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+cat <<'USERR' > "${TMP_DIR}/userr.conf"
+#!/usr/bin/env bash
+ENABLE_CADDY=0
+USERR
+
+export ARRSTACK_NO_MAIN=1
+export ARR_BASE="${TMP_DIR}"
+export ARR_USERCONF_PATH="${TMP_DIR}/userr.conf"
+export ENABLE_CADDY=1
+
+# shellcheck source=../../arrstack.sh disable=SC1091
+. "${REPO_ROOT}/arrstack.sh"
+
+if [[ "${ENABLE_CADDY:-}" != "1" ]]; then
+  printf 'Environment override lost; expected ENABLE_CADDY=1 but found %s\n' "${ENABLE_CADDY:-<unset>}" >&2
+  exit 1
+fi
+
+printf 'Environment override preserved: ENABLE_CADDY=%s\n' "${ENABLE_CADDY}"


### PR DESCRIPTION
## Summary
- capture the initial environment before sourcing defaults and mark expected variables as readonly when they came from the caller
- document the updated precedence order for environment exports, CLI flags, userr.conf, and the defaults
- add a regression script that proves an exported ENABLE_CADDY override survives userr.conf

## Testing
- `scripts/dev/verify-env-override-guard.sh`
- `shellcheck arrstack.sh scripts/dev/verify-env-override-guard.sh` *(fails: shellcheck not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cd0a3e6083298a80466f46774b5a