### PR TITLE
Guard exported environment overrides during user config load

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -107,7 +107,7 @@ if [[ -f "${_canon_userconf}" ]]; then
   trap - ERR
   set +e
   # shellcheck source=/dev/null
-  . "${_canon_userconf}" 2> >(tee "${_arrstack_userr_conf_errlog}" >&2)
+  . "${_canon_userconf}" 2>"${_arrstack_userr_conf_errlog}"
   _arrstack_userr_conf_status=$?
   set -e
   trap 'arrstack_err_trap' ERR
@@ -116,6 +116,8 @@ if [[ -f "${_canon_userconf}" ]]; then
       :
     else
       printf '[arrstack] Failed to source user config (status=%s): %s\n' "${_arrstack_userr_conf_status}" "${_canon_userconf}" >&2
+      # Replay captured stderr to aid debugging
+      cat "${_arrstack_userr_conf_errlog}" >&2 || :
       rm -f "${_arrstack_userr_conf_errlog}"
       exit "${_arrstack_userr_conf_status}"
     fi

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -85,7 +85,7 @@ for _arrstack_env_var in "${_arrstack_env_override_order[@]}"; do
         readonly "${_arrstack_env_var}" 2>/dev/null || :
       fi
     else
-      printf '[arrstack] WARN: Skipping readonly guard for invalid environment variable name: %s\n' "${_arrstack_env_var}" >&2
+      printf '[arrstack] WARN: Skipping readonly guard for invalid environment variable name: %s (must start with letter or underscore and contain only alphanumeric characters and underscores)\n' "${_arrstack_env_var}" >&2
     fi
   fi
 done

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,12 +2,13 @@
 
 # Configuration guide
 
-Edit `${ARR_BASE:-$HOME/srv}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and supporting files. `./arrstack.sh` now snapshots exported environment variables before loading your config and reapplies them afterwards so they continue to win over anything set inside `userr.conf` or the defaults.
+Edit `${ARR_BASE:-$HOME/srv}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and supporting files. `./arrstack.sh` snapshots exported environment variables, marks them read-only before sourcing your config, and reapplies them afterwards so they continue to win over anything set inside `userr.conf` or the defaults.
 
 ## Configuration layers
-1. **Shell environment** – anything exported before running `./arrstack.sh` overrides the other sources (use for CI or one-off toggles). Values are reasserted after `userr.conf` loads, except for internal read-only variables and normalized paths such as `ARR_USERCONF_PATH`, which may be canonicalised to an absolute path during startup.
-2. **`${ARR_BASE}/userr.conf`** – your persistent copy (defaults to `~/srv/userr.conf`). Keep it out of version control and rerun the installer after every edit.
-3. **`arrconf/userr.conf.defaults.sh`** – project defaults committed in the repo.
+1. **Shell environment** – anything exported before running `./arrstack.sh` overrides every other source (use for CI or one-off toggles). Values are made read-only while `userr.conf` loads and reasserted afterwards, except for internal read-only variables and normalized paths such as `ARR_USERCONF_PATH`, which may be canonicalised to an absolute path during startup.
+2. **CLI flags** – run-scoped toggles (for example `./arrstack.sh --enable-caddy`) apply after the read-only guard. Use them to temporarily override `userr.conf` without editing the file. Environment exports still win if both are present.
+3. **`${ARR_BASE}/userr.conf`** – your persistent copy (defaults to `~/srv/userr.conf`). Keep it out of version control and rerun the installer after every edit.
+4. **`arrconf/userr.conf.defaults.sh`** – project defaults committed in the repo.
 
 The installer prints a configuration table during preflight. Cancel with `Ctrl+C` if a value looks wrong, adjust `userr.conf`, and rerun.
 


### PR DESCRIPTION
## Summary
- mark exported environment overrides as read-only before sourcing `userr.conf` and skip invalid identifiers
- ensure the guard does not abort the run by tolerating readonly assignment failures while surfacing genuine config errors
- refresh the configuration guide to document the precedence of environment, CLI flags, user config, and defaults

## Testing
- `bash -n arrstack.sh`
- `shellcheck arrstack.sh` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d5b55ddc8329ba571644adc55edf