### PR TITLE
refactor: stream docker compose startup output

### DIFF
--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -624,27 +624,15 @@ validate_images() {
   return 0
 }
 
-# Starts individual compose service and prints any non-empty output
+# Starts individual compose service and streams docker compose output
 compose_up_service() {
   local service="$1"
-  local output=""
 
   msg "  Starting $service..."
-  if output="$(compose up -d "$service" 2>&1)"; then
-    if [[ "$output" == *"is up-to-date"* ]]; then
-      msg "  $service is up-to-date"
-    elif [[ -n "$output" ]]; then
-      while IFS= read -r line; do
-        printf '    %s\n' "$line"
-      done <<<"$output"
-    fi
+  if compose up -d "$service"; then
+    msg "  $service started"
   else
     warn "  Failed to start $service"
-    if [[ -n "$output" ]]; then
-      while IFS= read -r line; do
-        printf '    %s\n' "$line"
-      done <<<"$output"
-    fi
   fi
   sleep 2
 }
@@ -1216,24 +1204,13 @@ start_stack() {
   install_vuetorrent
 
   msg "Starting Gluetun VPN container..."
-  local gluetun_output=""
-  if ! gluetun_output="$(compose up -d gluetun 2>&1)"; then
+  if ! compose up -d gluetun; then
     warn "Failed to start Gluetun via docker compose"
-    if [[ -n "$gluetun_output" ]]; then
-      while IFS= read -r line; do
-        printf '  %s\n' "$line"
-      done <<<"$gluetun_output"
-    fi
     docker logs --tail=60 gluetun 2>&1 | sed 's/^/    /' || true
     arr_write_run_failure "VPN not running: failed to start Gluetun via docker compose." "VPN_NOT_RUNNING"
     return 1
   fi
-
-  if [[ -n "$gluetun_output" ]]; then
-    while IFS= read -r line; do
-      printf '  %s\n' "$line"
-    done <<<"$gluetun_output"
-  fi
+  msg "Gluetun container started"
 
   if ! arr_wait_for_gluetun_ready gluetun 150 5; then
     local failure_reason
@@ -1295,24 +1272,13 @@ start_stack() {
 
   for service in "${services[@]}"; do
     msg "Starting $service..."
-    local start_output=""
 
-    if start_output="$(compose up -d "$service" 2>&1)"; then
-      if [[ -n "$start_output" ]]; then
-        while IFS= read -r line; do
-          printf '  %s\n' "$line"
-        done <<<"$start_output"
-      fi
+    if compose up -d "$service"; then
       if [[ "$service" == "qbittorrent" ]]; then
         qb_started=1
       fi
     else
       warn "Failed to start $service"
-      if [[ -n "$start_output" ]]; then
-        while IFS= read -r line; do
-          printf '  %s\n' "$line"
-        done <<<"$start_output"
-      fi
       failed_services+=("$service")
       continue
     fi


### PR DESCRIPTION
### **User description**
## Summary
- stream docker compose output directly when starting individual services
- run the Gluetun startup with native docker compose output while retaining failure handling

## Impact
- operators can watch docker's native pull/recreate logs without extra formatting during startup

## Actions
- none

## Testing
- shellcheck scripts/services.sh *(reports existing SC2016 info + SC2034 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68e24af3883c8329afa55d9b0daaf0e9


___

### **PR Type**
Enhancement


___

### **Description**
- Stream docker compose output directly during service startup

- Remove custom output formatting and buffering logic

- Simplify error handling for compose operations

- Retain native docker compose logs for better visibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Custom Output Buffering"] --> B["Direct Streaming"]
  C["Formatted Messages"] --> D["Native Docker Logs"]
  E["Complex Error Handling"] --> F["Simplified Error Flow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services.sh</strong><dd><code>Simplify compose output streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/services.sh

<ul><li>Removed output buffering and custom formatting in <code>compose_up_service()</code><br> <li> Simplified Gluetun startup to stream output directly<br> <li> Eliminated complex output parsing logic in service startup loop<br> <li> Streamlined error handling by removing output capture</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/52/files#diff-985ca65c2253b80af787ea38fbff9233caff1d534f0560b1cc02dbf43961d45c">+6/-40</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined service startup logging to be concise and less noisy.
  - Replaced verbose per-line outputs with clear success/failure messages.
  - Standardised messages for container start events while preserving readiness checks.
- Chores
  - Removed unnecessary handling of “up-to-date” and other intermediate outputs.
  - Simplified control flow around service start feedback without changing behaviour.
  - Reduced terminal clutter to improve readability during stack start-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->