### PR TITLE
fix(installer): simplify userconf override lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Self-host the *arr stack with Proton VPN port forwarding on a Debian-based host.
    ```bash
    ./arr.sh --yes         # omit --yes for interactive mode
    ```
-   The script installs prerequisites, renders `.env` and `docker-compose.yml`, and starts the stack. Rerun it anytime after editing `userr.conf`.
+  The script installs prerequisites, renders `.env` and `docker-compose.yml`, and starts the stack. Rerun it anytime after editing `userr.conf`. The installer automatically searches the repo's parent directory and uses the first `userr.conf` it finds there (for example `../userr.conf` or `../arrconfigs/userr.conf`), so keep only the copy you want applied.
 6. **Access services.** Use the summary printed by the installer or browse to `http://LAN_IP:PORT` (for example `http://192.168.1.50:8082` for qBittorrent).
 
 ## Minimal configuration
-- `userr.conf` lives at `${ARR_BASE:-$HOME/srv}/userr.conf`; keep it outside version control.
+- `userr.conf` defaults to `${ARR_BASE:-$HOME/srv}/userr.conf`; keep it outside version control. If multiple overrides live alongside the repo, the installer loads the first file named `userr.conf` it finds above the repo.
 - Review these core values:
   - `LAN_IP`: private address of the host; required before ports are exposed.
 - `STACK`: project label used for generated paths and logs (defaults to `arr` via `STACK="${STACK:-arr}"`).

--- a/arr.sh
+++ b/arr.sh
@@ -213,7 +213,7 @@ for _arr_env_var in "${_arr_env_override_order[@]}"; do
     # Validate variable name format before assignment
     if [[ "${_arr_env_var}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
       printf -v "${_arr_env_var}" '%s' "${_arr_env_overrides[${_arr_env_var}]}"
-      export "${_arr_env_var?}"
+      export "${_arr_env_var}"
     else
       printf '%s WARN: Skipping invalid environment variable name: %s\n' "${STACK_TAG}" "${_arr_env_var}" >&2
     fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 # Configuration guide
 
-Edit `${ARR_BASE:-$HOME/srv}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and supporting files. `./arr.sh` snapshots exported environment variables, marks them read-only before sourcing your config, and reapplies them afterwards so they continue to win over anything set inside `userr.conf` or the defaults.
+Edit `${ARR_BASE:-$HOME/srv}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and supporting files. `./arr.sh` snapshots exported environment variables, marks them read-only before sourcing your config, and reapplies them afterwards so they continue to win over anything set inside `userr.conf` or the defaults. Before loading the file the installer searches the repo's parent directory for the first path named `userr.conf` (for example `../userr.conf` or `../overrides/site-a/userr.conf`) and uses that file; the same path is surfaced in the configuration preview so you can confirm which override will apply.
 
 ## Configuration layers
 1. **Shell environment** – anything exported before running `./arr.sh` overrides every other source (use for CI or one-off toggles). Values are made read-only while `userr.conf` loads and reasserted afterwards, except for internal read-only variables and normalized paths such as `ARR_USERCONF_PATH`, which may be canonicalised to an absolute path during startup.

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -132,6 +132,11 @@ show_configuration_preview() {
   fi
   qbt_whitelist_final="$(normalize_csv "$qbt_whitelist_final")"
 
+  local userconf_edit_target="${ARR_USERCONF_PATH}"
+  if [[ -n "${ARR_USERCONF_OVERRIDE_PATH:-}" ]]; then
+    userconf_edit_target="${ARR_USERCONF_OVERRIDE_PATH}"
+  fi
+
   cat <<CONFIG
 ------------------------------------------------------------
 ARR Stack configuration preview
@@ -176,7 +181,7 @@ Files that will be created/updated
   • Environment file: ${ARR_ENV_FILE}
   • Compose file: ${ARR_STACK_DIR}/docker-compose.yml
 
-If anything looks incorrect, edit ${ARR_USERCONF_PATH} before continuing.
+If anything looks incorrect, edit ${userconf_edit_target} before continuing.
 ------------------------------------------------------------
 CONFIG
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -542,6 +542,24 @@ preflight() {
 
   msg "  Permission profile: ${ARR_PERMISSION_PROFILE} (umask $(umask))"
 
+  local userconf_override_path=""
+  local default_userconf="${ARR_BASE:-${HOME}/srv}/userr.conf"
+  local default_userconf_canon
+  default_userconf_canon="$(readlink -f "$default_userconf" 2>/dev/null || printf '%s' "$default_userconf")"
+
+  if userconf_override_path="$(arr_find_userconf_override)" && [[ -n "$userconf_override_path" ]]; then
+    if [[ "$userconf_override_path" != "$default_userconf_canon" ]]; then
+      # shellcheck disable=SC2034  # consumed by scripts/config.sh
+      ARR_USERCONF_OVERRIDE_PATH="$userconf_override_path"
+    else
+      # shellcheck disable=SC2034  # consumed by scripts/config.sh
+      ARR_USERCONF_OVERRIDE_PATH=""
+    fi
+  else
+    # shellcheck disable=SC2034  # consumed by scripts/config.sh
+    ARR_USERCONF_OVERRIDE_PATH=""
+  fi
+
   if [[ ! -f "${ARRCONF_DIR}/proton.auth" ]]; then
     die "Missing ${ARRCONF_DIR}/proton.auth - create it with PROTON_USER and PROTON_PASS"
   fi


### PR DESCRIPTION
### **User description**
## Summary
- replace the override discovery helper with a compact implementation that canonicalises explicit ARR_USERCONF_PATH values and searches the repo parent for the first userr.conf
- add a reusable realpath helper that prefers `realpath`, falls back to `readlink -f`, and otherwise echoes the raw path

## Impact
- arr.sh and preflight reuse the streamlined finder to honour explicit overrides and automatically pick the first sibling userr.conf found alongside the repo

## Testing
- shellcheck arr.sh scripts/preflight.sh scripts/config.sh *(SC2034 warnings about ARR_INTERNAL_PORT_CONFLICTS and ARR_INTERNAL_PORT_CONFLICT_DETAIL already existed)*
- ./arr.sh --help


------
https://chatgpt.com/codex/tasks/task_e_68e28cdfc5b4832983cd31a1a6edb454


___

### **PR Type**
Enhancement


___

### **Description**
- Simplify userconf override lookup with streamlined implementation

- Add automatic discovery of `userr.conf` files in parent directories

- Introduce reusable `realpath` helper with fallback support

- Update configuration preview to show correct override path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variable ARR_USERCONF_PATH"] --> B["Override Discovery Function"]
  B --> C["Search Parent Directory"]
  C --> D["Find First userr.conf"]
  D --> E["Canonicalize Path"]
  E --> F["Update Configuration Preview"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>arr.sh</strong><dd><code>Core override discovery and path resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

arr.sh

<ul><li>Add <code>_arr_realpath_echo</code> helper function with fallback logic<br> <li> Implement <code>arr_find_userconf_override</code> for automatic config discovery<br> <li> Replace complex override logic with streamlined implementation<br> <li> Add canonicalization and source tracking for userconf paths</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/58/files#diff-90d48d4031c48b3c84f710701a342ddb7318b8a17c35fce4ac02f2a765dfb3d5">+70/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.sh</strong><dd><code>Configuration preview path correction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/config.sh

<ul><li>Update configuration preview to show correct userconf edit target<br> <li> Use override path when available instead of default path</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/58/files#diff-e52229475913ead2a19b9c4be787d753170d054136228f98c3e427452e7bc2ca">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>preflight.sh</strong><dd><code>Preflight override path detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/preflight.sh

<ul><li>Add userconf override discovery in preflight checks<br> <li> Set <code>ARR_USERCONF_OVERRIDE_PATH</code> variable for downstream consumption<br> <li> Compare override path with default to avoid redundant assignments</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/58/files#diff-796902aa575008e61cd876573ca64ca0c5e74e1fcc56d7fe025c459d44b76444">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Documentation updates for automatic discovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Update documentation to explain automatic userconf discovery<br> <li> Clarify that installer searches parent directory for config files</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/58/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configuration.md</strong><dd><code>Configuration guide enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/configuration.md

<ul><li>Add detailed explanation of automatic userconf discovery behavior<br> <li> Document how installer searches parent directories for override files</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/58/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic detection of user configuration overrides in repository/parent directories.
  - Canonicalised user configuration path, with explicit override support.
  - Configuration preview now highlights the correct file to edit when an override is used.
- Behaviour Changes
  - Environment variable exports now enforce presence, reducing misconfiguration.
  - Non-override config paths outside the base are restricted unless explicitly allowed.
- Bug Fixes
  - Preview reliably reflects the active override file.
- Documentation
  - Updated configuration guide to describe override search and preview behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->