### PR TITLE
fix: restore ~/srv defaults for ARR_DATA_ROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Self-host the *arr stack with Proton VPN port forwarding on a Debian-based host.
    ```
    > The installer expects these dependencies to be present already; it does not install Docker, Compose, or CLI tools on your behalf.
 2. **Clone arrbash and enter the directory.**
-   ```bash
-   mkdir -p ~/srv && cd ~/srv
-   git clone https://github.com/cbkii/arrbash.git
-   cd arrbash
-   ```
+    ```bash
+    mkdir -p ~/srv && cd ~/srv
+    git clone https://github.com/cbkii/arrbash.git
+    cd arrbash
+    ```
 3. **Add Proton credentials.**
    ```bash
    cp arrconf/proton.auth.example arrconf/proton.auth
@@ -42,11 +42,12 @@ Self-host the *arr stack with Proton VPN port forwarding on a Debian-based host.
 6. **Access services.** Use the summary printed by the installer or browse to `http://LAN_IP:PORT` (for example `http://192.168.1.50:8082` for qBittorrent).
 
 ## Minimal configuration
-- `userr.conf` defaults to `${ARR_BASE:-$HOME/srv}/userr.conf`; keep it outside version control. If multiple overrides live alongside the repo, the installer loads the first file named `userr.conf` it finds above the repo.
+- `ARR_DATA_ROOT`: top-level data directory for the stack (defaults to `~/srv`). Override it via the environment or `userr.conf` before running `./arr.sh`.
+- `userr.conf` defaults to `${ARR_BASE:-$ARR_DATA_ROOT}/userr.conf`; keep it outside version control. If multiple overrides live alongside the repo, the installer loads the first file named `userr.conf` it finds above the repo.
 - Review these core values:
   - `LAN_IP`: private address of the host; required before ports are exposed.
 - `STACK`: project label used for generated paths and logs (defaults to `arr` via `STACK="${STACK:-arr}"`).
-- `ARR_BASE`: base directory for generated files (defaults to `~/srv`).
+- `ARR_BASE`: base directory for generated files (defaults to `ARR_DATA_ROOT`).
   - `DOWNLOADS_DIR`, `COMPLETED_DIR`, `MEDIA_DIR`: map to your storage paths.
   - `SPLIT_VPN`: set to `1` to tunnel only qBittorrent; leave `0` for full VPN mode.
   - `ENABLE_CADDY`, `ENABLE_LOCAL_DNS`, `ENABLE_CONFIGARR`: toggle optional HTTPS/DNS/Configarr services.

--- a/arr.sh
+++ b/arr.sh
@@ -48,7 +48,7 @@ _arr_userconf_source="default"
 
 arr_resolve_userconf_paths ARR_USERCONF_PATH ARR_USERCONF_OVERRIDE_PATH _arr_userconf_source
 
-_expected_base="${ARR_BASE:-${HOME}/srv}"
+_expected_base="${ARR_BASE:-${ARR_DATA_ROOT}}"
 _canon_base="$(arr_canonical_path "${_expected_base}")"
 _canon_userconf="${ARR_USERCONF_PATH}"
 

--- a/arrconf/userr.conf.defaults.sh
+++ b/arrconf/userr.conf.defaults.sh
@@ -3,7 +3,7 @@
 # This file is sourced *before* ${ARR_BASE}/userr.conf.
 # Keep assignments idempotent and avoid relying on side effects so overrides
 # behave predictably when the user configuration runs afterwards.
-# Override these in ${ARR_BASE}/userr.conf (git-ignored; defaults to ${HOME}/srv/userr.conf).
+# Override these in ${ARR_BASE}/userr.conf (git-ignored; defaults to ${ARR_DATA_ROOT}/userr.conf where ARR_DATA_ROOT defaults to ~/srv).
 
 # Guard helpers for shells that source these defaults alongside other scripts
 if ! declare -f arr_var_is_readonly >/dev/null 2>&1; then
@@ -29,7 +29,16 @@ fi
 STACK="${STACK:-arr}"
 STACK_UPPER="${STACK_UPPER:-${STACK^^}}"
 export STACK STACK_UPPER
-ARR_BASE="${ARR_BASE:-${HOME}/srv}"
+
+if [[ -z "${ARR_DATA_ROOT:-}" ]]; then
+  if [[ -n "${HOME:-}" ]]; then
+    ARR_DATA_ROOT="${HOME%/}/srv"
+  else
+    ARR_DATA_ROOT="/srv/${STACK}"
+  fi
+fi
+
+ARR_BASE="${ARR_BASE:-${ARR_DATA_ROOT}}"
 ARR_STACK_DIR="${ARR_STACK_DIR:-${ARR_BASE}/${STACK}}"
 ARR_DOCKER_DIR="${ARR_DOCKER_DIR:-${ARR_BASE}/docker-data}"
 ARR_ENV_FILE="${ARR_ENV_FILE:-${ARR_STACK_DIR}/.env}"
@@ -516,12 +525,13 @@ arr_render_userconf_template() {
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 # Keep arrconf/userr.conf.example in sync with any changes made here.
-# Copy to ${ARR_BASE}/userr.conf (default: ${HOME}/srv/userr.conf) and edit as needed.
+# Copy to ${ARR_BASE}/userr.conf (default: ${ARR_DATA_ROOT}/userr.conf) and edit as needed.
 # Values here override the defaults from arrconf/userr.conf.defaults.sh, which loads first.
 
 # --- Stack paths ---
 STACK="${STACK}"                    # Project identifier used for directories, logs, and labels
-ARR_BASE="${HOME}/srv"                 # Root directory for generated stack files
+ARR_DATA_ROOT="${HOME}/srv"           # Default data root (matches historical ~/srv layout)
+ARR_BASE="${ARR_DATA_ROOT}"           # Root directory for generated stack files
 ARR_STACK_DIR="${ARR_BASE}/${STACK}"  # Location for docker-compose.yml, scripts, and aliases
 ARR_ENV_FILE="${ARR_STACK_DIR}/.env"  # Path to the generated .env secrets file
 ARR_DOCKER_DIR="${ARR_BASE}/docker-data"  # Docker volumes and persistent data storage

--- a/arrconf/userr.conf.example
+++ b/arrconf/userr.conf.example
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 # When updating arrconf/userr.conf.defaults.sh, manually review and update this example file to match any new or changed default variables.
-# Copy to ${ARR_BASE}/userr.conf (default: ${HOME}/srv/userr.conf) and edit as needed.
+# Copy to ${ARR_BASE}/userr.conf (default: ${ARR_DATA_ROOT}/userr.conf) and edit as needed.
 # Values here override the defaults from arrconf/userr.conf.defaults.sh, which loads first.
 
 # --- Quick start — who & when ---
@@ -12,7 +12,8 @@ PGID="$(id -g)"                        # Numeric group ID with write access (mat
 ARR_PERMISSION_PROFILE="strict"        # strict keeps secrets 600/700, collab enables group read/write (660/770)
 
 # --- Essential paths ---
-ARR_BASE="${HOME}/srv"                 # Root directory for generated stack files
+ARR_DATA_ROOT="${HOME}/srv"           # Default data root (matches historical ~/srv layout)
+ARR_BASE="${ARR_DATA_ROOT}"           # Root directory for generated stack files
 ARR_STACK_DIR="${ARR_BASE}/${STACK}"  # Location for docker-compose.yml, scripts, and aliases
 DOWNLOADS_DIR="${HOME}/Downloads"      # Active qBittorrent download folder
 COMPLETED_DIR="${DOWNLOADS_DIR}/completed"  # Destination for completed downloads

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,12 +2,12 @@
 
 # Configuration guide
 
-Edit `${ARR_BASE:-$HOME/srv}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and supporting files. `./arr.sh` snapshots exported environment variables, marks them read-only before sourcing your config, and reapplies them afterwards so they continue to win over anything set inside `userr.conf` or the defaults. Before loading the file the installer searches the repo's parent directory for the first path named `userr.conf` (for example `../userr.conf` or `../overrides/site-a/userr.conf`) and uses that file; the same path is surfaced in the configuration preview so you can confirm which override will apply.
+Edit `${ARR_BASE:-$ARR_DATA_ROOT}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and supporting files. `ARR_DATA_ROOT` defaults to `~/srv`, keeping generated assets under the historical data directory unless you override it. `./arr.sh` snapshots exported environment variables, marks them read-only before sourcing your config, and reapplies them afterwards so they continue to win over anything set inside `userr.conf` or the defaults. Before loading the file the installer searches the repo's parent directory for the first path named `userr.conf` (for example `../userr.conf` or `../overrides/site-a/userr.conf`) and uses that file; the same path is surfaced in the configuration preview so you can confirm which override will apply.
 
 ## Configuration layers
 1. **Shell environment** – anything exported before running `./arr.sh` overrides every other source (use for CI or one-off toggles). Values are made read-only while `userr.conf` loads and reasserted afterwards, except for internal read-only variables and normalized paths such as `ARR_USERCONF_PATH`, which may be canonicalised to an absolute path during startup.
 2. **CLI flags** – run-scoped toggles (for example `./arr.sh --enable-caddy`) apply after the read-only guard. Use them to temporarily override `userr.conf` without editing the file. Environment exports still win if both are present.
-3. **`${ARR_BASE}/userr.conf`** – your persistent copy (defaults to `~/srv/userr.conf`). Keep it out of version control and rerun the installer after every edit.
+3. **`${ARR_BASE}/userr.conf`** – your persistent copy (defaults to `${ARR_DATA_ROOT}/userr.conf`). Keep it out of version control and rerun the installer after every edit.
 4. **`arrconf/userr.conf.defaults.sh`** – project defaults committed in the repo.
 
 The installer prints a configuration table during preflight. Cancel with `Ctrl+C` if a value looks wrong, adjust `userr.conf`, and rerun.
@@ -25,7 +25,8 @@ The installer prints a configuration table during preflight. Cancel with `Ctrl+C
   - `DNS_DISTRIBUTION_MODE`: choose `router` (default) to update DHCP Option 6, or `per-device` when pointing clients at the resolver manually.
   - `ARR_PORT_CHECK_MODE`: `enforce` (default) fails fast on conflicts, `warn` prints notices, and `skip` disables port validation (use sparingly).
 - **Paths & storage**
-  - `ARR_BASE`: root directory for generated files and Docker data (default `~/srv`).
+  - `ARR_DATA_ROOT`: top-level data directory (defaults to `~/srv`). Override it before running the installer if you want a different layout.
+  - `ARR_BASE`: root directory for generated files and Docker data (defaults to `ARR_DATA_ROOT`).
   - `DOWNLOADS_DIR`, `COMPLETED_DIR`, `MEDIA_DIR`: map to your storage volumes.
   - `ARR_LOG_DIR`: location for installer and helper logs if you prefer another disk.
 - **Credentials & preservation**
@@ -46,7 +47,7 @@ The installer prints a configuration table during preflight. Cancel with `Ctrl+C
   - Optional overrides: `ARR_UMASK_OVERRIDE`, `ARR_DATA_DIR_MODE_OVERRIDE`, `ARR_NONSECRET_FILE_MODE_OVERRIDE`, `ARR_SECRET_FILE_MODE_OVERRIDE` for advanced tuning.
 
 ## Working with overrides
-1. Edit `~/srv/userr.conf` (or the path set in `ARR_BASE`).
+1. Edit `${ARR_BASE:-$ARR_DATA_ROOT}/userr.conf` (or the path set in `ARR_BASE`).
 2. Save the file and rerun:
    ```bash
    ./arr.sh --yes

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -5,7 +5,7 @@
 Use these commands to run the installer safely, rotate credentials, and call helper scripts.
 
 ## Installer basics
-- `./arr.sh` is idempotent. Rerun it after editing `${ARR_BASE:-$HOME/srv}/userr.conf`; the script regenerates `.env`, `docker-compose.yml`, the Caddyfile, and helper assets before starting containers.
+- `./arr.sh` is idempotent. Rerun it after editing `${ARR_BASE:-$ARR_DATA_ROOT}/userr.conf`; the script regenerates `.env`, `docker-compose.yml`, the Caddyfile, and helper assets before starting containers.
 - Key flags (combine as needed):
 
   ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -67,7 +67,7 @@ Follow these checks when services fail to start, DNS stops resolving, or VPN hel
 ### VPN auto-reconnect inactive
 - Confirm the feature is enabled:
   ```bash
-  grep VPN_AUTO_RECONNECT_ENABLED ${ARR_BASE:-$HOME/srv}/userr.conf
+  grep VPN_AUTO_RECONNECT_ENABLED ${ARR_BASE:-$ARR_DATA_ROOT}/userr.conf
   ```
 - Clear pause/kill overrides:
   ```bash

--- a/docs/version-management.md
+++ b/docs/version-management.md
@@ -22,7 +22,7 @@ The stack pins each image to a tested tag. Registries occasionally remove old ma
 ## Update workflow
 1. Back up your data:
    ```bash
-   cd "${ARR_BASE:-$HOME/srv}"
+   cd "${ARR_BASE:-$ARR_DATA_ROOT}"
    STACK="${STACK:-arr}"
    tar -czf "${STACK}-backup-$(date +%Y%m%d).tar.gz" "$(basename "${ARR_STACK_DIR:-${STACK}}")" docker-data
    ```

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -13,6 +13,18 @@
 : "${DATA_DIR_MODE:=700}"
 : "${LOCK_FILE_MODE:=640}"
 
+if [[ -z "${ARR_DATA_ROOT:-}" ]]; then
+  if [[ -n "${HOME:-}" ]]; then
+    ARR_DATA_ROOT="${HOME%/}/srv"
+  else
+    ARR_DATA_ROOT="/srv/${STACK}"
+  fi
+fi
+
+if [[ -z "${ARR_BASE:-}" ]]; then
+  ARR_BASE="${ARR_DATA_ROOT}"
+fi
+
 # shellcheck disable=SC2034  # exported for other modules
 STACK_LABEL="[${STACK}]"
 
@@ -180,13 +192,19 @@ arr_docker_data_root() {
     return
   fi
 
-  local home_dir="${HOME:-}"
-  if [[ -n "$home_dir" ]]; then
-    printf '%s' "${home_dir%/}/srv/docker-data"
+  local base_root="${ARR_BASE:-${ARR_DATA_ROOT:-}}"
+  if [[ -n "$base_root" ]]; then
+    printf '%s/docker-data' "${base_root%/}"
     return
   fi
 
-  printf '%s' "./srv/docker-data"
+  local home_dir="${HOME:-}"
+  if [[ -n "$home_dir" ]]; then
+    printf '%s/srv/docker-data' "${home_dir%/}"
+    return
+  fi
+
+  printf '%s' "/srv/${STACK}/docker-data"
 }
 
 # Resolves the Gluetun data directory under the docker-data root

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -23,9 +23,14 @@ fi
 # Seeds global defaults, handling collaborative profile toggles and legacy overrides
 arr_setup_defaults() {
   local previous_stack_dir="${ARR_STACK_DIR:-}"
-  if [[ -z "${ARR_DOCKER_DIR}" && -d "${HOME}/srv/docker-data" ]]; then
-    ARR_DOCKER_DIR="${HOME}/srv/docker-data"
-    ARR_STACK_DIR="${ARR_STACK_DIR:-${PWD}/${STACK}}"
+  local default_docker_root=""
+  if [[ -n "${ARR_DATA_ROOT:-}" ]]; then
+    default_docker_root="${ARR_DATA_ROOT%/}/docker-data"
+  fi
+
+  if [[ -z "${ARR_DOCKER_DIR}" && -n "${default_docker_root}" && -d "${default_docker_root}" ]]; then
+    ARR_DOCKER_DIR="${default_docker_root}"
+    ARR_STACK_DIR="${ARR_STACK_DIR:-${ARR_BASE:-${ARR_DATA_ROOT}}/${STACK}}"
   fi
 
   if [[ -n "${previous_stack_dir}" && "${previous_stack_dir}" != "${ARR_STACK_DIR}" ]]; then

--- a/scripts/export-caddy-ca.sh
+++ b/scripts/export-caddy-ca.sh
@@ -7,7 +7,7 @@ STACK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # shellcheck source=scripts/common.sh
 . "${STACK_DIR}/scripts/common.sh"
 
-CA_ROOT="${ARR_DOCKER_DIR:-${HOME}/srv/docker-data}/caddy/data/caddy/pki/authorities/local"
+CA_ROOT="$(arr_docker_data_root)/caddy/data/caddy/pki/authorities/local"
 CA_FILE="${CA_ROOT}/root.crt"
 DEST_FILE="${1:-${HOME}/${STACK}-ca.crt}"
 

--- a/scripts/files.sh
+++ b/scripts/files.sh
@@ -290,7 +290,7 @@ write_env() {
   SPLIT_VPN="$split_vpn"
 
   local direct_ports_requested="${EXPOSE_DIRECT_PORTS:-0}"
-  local userconf_path="${ARR_USERCONF_PATH:-${ARR_BASE:-${HOME}/srv}/userr.conf}"
+  local userconf_path="${ARR_USERCONF_PATH:-${ARR_BASE:-${ARR_DATA_ROOT}}/userr.conf}"
 
   if ((split_vpn == 1)); then
     if [[ "${ENABLE_CADDY:-0}" -ne 0 ]]; then
@@ -1241,7 +1241,7 @@ write_compose() {
   local include_caddy=0
   local include_local_dns=0
   local -a upstream_dns_servers=()
-  local userconf_path="${ARR_USERCONF_PATH:-${ARR_BASE:-${HOME}/srv}/userr.conf}"
+  local userconf_path="${ARR_USERCONF_PATH:-${ARR_BASE:-${ARR_DATA_ROOT}}/userr.conf}"
 
   mapfile -t upstream_dns_servers < <(collect_upstream_dns_servers)
 
@@ -2056,7 +2056,7 @@ write_caddy_assets() {
   local data_dir="${caddy_root}/data"
   local config_dir="${caddy_root}/config"
   local caddyfile="${caddy_root}/Caddyfile"
-  local userconf_path="${ARR_USERCONF_PATH:-${ARR_BASE:-${HOME}/srv}/userr.conf}"
+  local userconf_path="${ARR_USERCONF_PATH:-${ARR_BASE:-${ARR_DATA_ROOT}}/userr.conf}"
 
   ensure_dir "$caddy_root"
   ensure_dir "$data_dir"

--- a/scripts/gluetun.sh
+++ b/scripts/gluetun.sh
@@ -68,7 +68,7 @@ _pf_gluetun_root() {
     if [[ -n "${ARR_STACK_DIR:-}" ]]; then
       base="${ARR_STACK_DIR%/}/docker-data"
     else
-      base="${HOME:-.}/srv/docker-data"
+      base="${ARR_DATA_ROOT%/}/docker-data"
     fi
   fi
   printf '%s/gluetun' "${base%/}"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -609,7 +609,7 @@ preflight() {
 
   msg "  Permission profile: ${ARR_PERMISSION_PROFILE} (umask $(umask))"
 
-  local default_userconf="${ARR_BASE:-${HOME}/srv}/userr.conf"
+  local default_userconf="${ARR_BASE:-${ARR_DATA_ROOT}}/userr.conf"
   local default_userconf_canon
   default_userconf_canon="$(arr_canonical_path "$default_userconf")"
 

--- a/scripts/qbt-helper.sh
+++ b/scripts/qbt-helper.sh
@@ -56,7 +56,10 @@ resolve_docker_data() {
   if [[ -n "${ARR_DOCKER_DIR:-}" ]]; then
     candidates+=("$ARR_DOCKER_DIR")
   fi
-  candidates+=("${HOME}/srv/docker-data" "${STACK_DIR}/docker-data")
+  if [[ -n "${ARR_DATA_ROOT:-}" ]]; then
+    candidates+=("${ARR_DATA_ROOT%/}/docker-data")
+  fi
+  candidates+=("${STACK_DIR}/docker-data")
 
   local path
   for path in "${candidates[@]}"; do

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -629,7 +629,7 @@ compose_service_is_running() {
   local service="$1"
   local project
 
-  project="$(arr_effective_project_name 2>/dev/null || printf 'arrstack')"
+  project="$(arr_effective_project_name 2>/dev/null || printf '%s' "${STACK}")"
 
   docker ps \
     --filter "label=com.docker.compose.project=${project}" \

--- a/scripts/summary.sh
+++ b/scripts/summary.sh
@@ -281,7 +281,7 @@ WARNING
     if [[ -n "${ARR_STACK_DIR:-}" ]]; then
       vpn_auto_state_base="${ARR_STACK_DIR%/}/docker-data"
     else
-      vpn_auto_state_base="${HOME:-.}/srv/docker-data"
+      vpn_auto_state_base="${ARR_DATA_ROOT%/}/docker-data"
     fi
   fi
   local vpn_auto_state_file="${vpn_auto_state_base%/}/gluetun/auto-reconnect/state.json"

--- a/scripts/userconf.sh
+++ b/scripts/userconf.sh
@@ -55,7 +55,7 @@ arr_find_userconf_override() {
 
 # Resolve the effective userr.conf path, preferring an explicit ARR_USERCONF_PATH
 # when set, otherwise falling back to the first sibling override and finally the
-# default under ARR_BASE (or $HOME/srv when unset). Sets the provided variable
+# default under ARR_BASE (or ARR_DATA_ROOT when unset). Sets the provided variable
 # names to the canonical path, discovered override, and source label.
 arr_resolve_userconf_paths() {
   local __path_var="$1"
@@ -73,7 +73,7 @@ arr_resolve_userconf_paths() {
       candidate="${override}"
       source="override"
     else
-      candidate="${ARR_BASE:-${HOME}/srv}/userr.conf"
+      candidate="${ARR_BASE:-${ARR_DATA_ROOT}}/userr.conf"
       source="default"
       override=""
     fi

--- a/scripts/vpn-auto-reconnect.sh
+++ b/scripts/vpn-auto-reconnect.sh
@@ -35,7 +35,7 @@ vpn_auto_gluetun_root() {
     if [[ -n "${ARR_STACK_DIR:-}" ]]; then
       base="${ARR_STACK_DIR%/}/docker-data"
     else
-      base="${HOME:-.}/srv/docker-data"
+      base="${ARR_DATA_ROOT%/}/docker-data"
     fi
   fi
   printf '%s/gluetun' "${base%/}"


### PR DESCRIPTION
### **User description**
## Summary
- set the ARR_DATA_ROOT default back to the historical ~/srv path and update fallbacks to respect ${STACK}
- remove hardcoded arrstack references from defaults, helpers, and compose helpers while keeping group ordering intact
- revert README quick start cloning instructions and refresh configuration docs to match the restored default

## Impact
- installs once again land under ~/srv by default, while custom ARR_DATA_ROOT values remain supported

## Testing
- shellcheck arrconf/userr.conf.defaults.sh arrconf/userr.conf.example scripts/common.sh scripts/services.sh *(existing warnings in untouched sections)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ad5c97d4832998f54c09672677b8


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restore `~/srv` as default data root path

- Remove hardcoded `arrstack` references throughout codebase

- Add `ARR_DATA_ROOT` variable with stack-aware fallbacks

- Update documentation to reflect restored defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ARR_DATA_ROOT"] --> B["~/srv (default)"]
  A --> C["/srv/${STACK} (fallback)"]
  B --> D["ARR_BASE"]
  C --> D
  D --> E["Stack directories"]
  F["Hardcoded paths"] --> G["Dynamic stack-aware paths"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>arr.sh</strong><dd><code>Update base path resolution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-90d48d4031c48b3c84f710701a342ddb7318b8a17c35fce4ac02f2a765dfb3d5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>defaults.sh</strong><dd><code>Use dynamic paths instead of hardcoded</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-62864d3fd9170d4353b0d74e3498816a14efae7e32b6ab7919d08f66a2334308">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export-caddy-ca.sh</strong><dd><code>Replace hardcoded path with helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-c848dfa01e1e7d4e03a73658feb946bd06c4b6d456f6cd62034c5e1f7b118c29">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>files.sh</strong><dd><code>Update userconf path references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-a33e361169c3c851e6a6efdfc11feae384b52a28e475fb16ef6eb80241299b6f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gluetun.sh</strong><dd><code>Replace hardcoded path with ARR_DATA_ROOT</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-c2a1017ae6e6396e965b1f281dceb3ea2e46b327bb27338fc00e42937cc072a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>preflight.sh</strong><dd><code>Update default userconf path reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-796902aa575008e61cd876573ca64ca0c5e74e1fcc56d7fe025c459d44b76444">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.sh</strong><dd><code>Remove hardcoded arrstack project name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-985ca65c2253b80af787ea38fbff9233caff1d534f0560b1cc02dbf43961d45c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>summary.sh</strong><dd><code>Replace hardcoded path with ARR_DATA_ROOT</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-cd289607d90092554453561750b68e3906b47126d6fa3ef3646fd580d0cac8bb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vpn-auto-reconnect.sh</strong><dd><code>Replace hardcoded path with ARR_DATA_ROOT</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-ef3361c6200914a275cca70726c4c14ebc16be25112cf9ecbe42aa9233eb1d6c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>userr.conf.defaults.sh</strong><dd><code>Add ARR_DATA_ROOT with fallback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-3696fadcc01ebdaa1fe61774b995b6837a8473a819bd6aa70d9f99f99f1793fe">+14/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>common.sh</strong><dd><code>Initialize ARR_DATA_ROOT and update path helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-b23204e92f793e233cf28605758e6f1d4849830577492c85f00593f977527e27">+20/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qbt-helper.sh</strong><dd><code>Add ARR_DATA_ROOT to path candidates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-8912cf8666e3d92c217a721b575d329ca8bdcb4cd9a34f6f5294a91eaf9c8915">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>userconf.sh</strong><dd><code>Update userconf path resolution comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-aee801a27f1e1c998c7fc3c037a4b531461009612cfe420c43cab224f1383c1c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>userr.conf.example</strong><dd><code>Add ARR_DATA_ROOT variable example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-97bd393a0fbd9e9f9325c0c5c5d91915976ad8154e7f9fae63cf6e4d69b208eb">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.md</strong><dd><code>Update path documentation and examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>operations.md</strong><dd><code>Update installer path reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-ad74991b96593fdee570962fc5b1e319080abd55e16614f556f74b7de8fd02d1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>troubleshooting.md</strong><dd><code>Update path reference in examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>version-management.md</strong><dd><code>Update backup command path reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/60/files#diff-1cf00b5dc8ea5e6fdc8ccc3bb954e5ea64de1e1cb39370f168bbadbe10659686">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardised default data root to ARR_DATA_ROOT (defaults to ~/srv) and set ARR_BASE to use it by default.
  - Updated default locations for user configuration, docker data, and VPN state to derive from ARR_DATA_ROOT.
  - Adjusted service detection to default to the current STACK name when project resolution fails.

- Documentation
  - Revised configuration, operations, troubleshooting, and version management guides to reflect ARR_DATA_ROOT as the canonical base.
  - Updated examples and paths to use ARR_BASE:-$ARR_DATA_ROOT instead of HOME-based defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->