### PR TITLE
docs: sync guides with current behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Self-host the *arr stack with Proton VPN port forwarding on a Debian-based host.
    ```bash
    ./arr.sh --yes         # omit --yes for interactive mode
    ```
-  The script installs prerequisites, renders `.env` and `docker-compose.yml`, and starts the stack. Rerun it anytime after editing `userr.conf`. The installer first searches under `${ARR_DATA_ROOT}` (depth 4) and then the repo's parent directory for the first `userr.conf` it finds (for example `${ARR_DATA_ROOT}/arrconfigs/userr.conf` or `../userr.conf`), so keep only the copy you want applied.
-6. **Access services.** Use the summary printed by the installer or browse to `http://LAN_IP:PORT` (for example `http://192.168.1.50:8082` for qBittorrent).
+  The script checks that Docker, Compose, and helper tools are ready, then rebuilds `.env`, `docker-compose.yml`, and supporting files before starting the stack. Rerun it anytime after editing `userr.conf`. The installer first searches under `${ARR_DATA_ROOT}` (depth 4) and then the repo's parent directory for the first `userr.conf` it finds (for example `${ARR_DATA_ROOT}/arrconfigs/userr.conf` or `../userr.conf`), so keep only the copy you want applied.
+6. **Access services.** Follow the summary printed by the installer or browse to `http://LAN_IP:PORT` (for example `http://192.168.1.50:8082` for qBittorrent).
 
 ## Minimal configuration
 - `ARR_DATA_ROOT`: top-level data directory for the stack (defaults to `~/srv`). Override it via the environment or `userr.conf` before running `./arr.sh`.
@@ -48,7 +48,7 @@ Self-host the *arr stack with Proton VPN port forwarding on a Debian-based host.
 - `userr.conf` and `proton.auth` both default to `${ARRCONF_DIR}`; keep them outside version control. If multiple overrides exist, the installer looks under `${ARR_DATA_ROOT}` (depth 4) and then above the repo for the first `userr.conf` it finds.
 - Review these core values:
   - `LAN_IP`: private address of the host; required before ports are exposed.
-- `STACK`: project label used for generated paths and logs (defaults to `arr` via `STACK="${STACK:-arr}"`).
+- `STACK`: project label used for generated paths and logs (defaults to `arr`).
 - `ARR_DATA_ROOT` also determines generated stack paths and the default location of Proton credentials and overrides.
   - `DOWNLOADS_DIR`, `COMPLETED_DIR`, `MEDIA_DIR`: defaults sit under `${ARR_DATA_ROOT}` (for example `${ARR_DATA_ROOT}/media`), but you should point each one at your actual storage volume in `userr.conf`.
   - `SPLIT_VPN`: set to `1` to tunnel only qBittorrent; leave `0` for full VPN mode.
@@ -99,7 +99,7 @@ SABNZBD_TIMEOUT=15         # Helper/API timeout in seconds
 # Set SABNZBD_IMAGE=ghcr.io/linuxserver/sabnzbd:latest to pin an alternate container tag
 ```
 
-After your first SABnzbd login, paste the API key into the WebUI once; reruns will hydrate
+After your first SABnzbd login, paste the API key into the WebUI once; reruns hydrate
 `SABNZBD_API_KEY` from `sabnzbd.ini` automatically.
 
 To enable SABnzbd for a single installer run without editing `userr.conf`, pass `--enable-sab`:
@@ -110,19 +110,6 @@ To enable SABnzbd for a single installer run without editing `userr.conf`, pass 
 
 Refer to [docs/sabnzbd.md](docs/sabnzbd.md) for networking scenarios, API key preservation,
 and helper usage tips.
-
-Run:
-
-```bash
-./arr.sh --yes
-```
-
-Helper:
-
-```bash
-scripts/sab-helper.sh status
-scripts/sab-helper.sh add-file /path/to/file.nzb
-```
 
 VPN note:
 By default SAB runs outside the VPN (TLS to Usenet servers). Enable `SABNZBD_USE_VPN=1` for full tunnelling through Gluetun.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ This stack renders configuration from a small set of scripts, then launches Dock
 | FlareSolverr | Captcha solver service used by indexers. | `http://LAN_IP:${FLARR_PORT}`. |
 | Configarr (optional) | Keeps Sonarr/Radarr configuration in sync. | Runs headless; configure via Configarr secrets. |
 | Caddy (optional) | HTTPS reverse proxy with internal CA. | `https://<service>.<LAN_DOMAIN_SUFFIX>` with basic auth for remote access. |
-| local_dns (optional) | dnsmasq-based resolver that answers `*.home.arpa`. | List the Pi as primary DNS on clients. |
+| local_dns (optional) | dnsmasq-based resolver that answers `*.home.arpa`. | List the arrbash host as primary DNS on clients. |
 
 The installer publishes LAN ports when `EXPOSE_DIRECT_PORTS=1`. When disabled, access services via Docker networks or the optional proxy.
 
@@ -31,7 +31,7 @@ Generated files should not be edited manually; adjust `userr.conf` and rerun the
 1. **Preflight** – checks dependencies, confirms Docker availability, validates Proton credentials, and ensures required ports are free before writing files.
 2. **Defaults and overrides** – sources `arrconf/userr.conf.defaults.sh`, applies environment variables, then your `${ARRCONF_DIR}/userr.conf` values.
 3. **File rendering** – creates directories with safe permissions, hydrates preserved secrets from existing `.env`, and writes compose/env/proxy files in atomic steps.
-4. **Service start** – launches Gluetun first, waits for port forwarding, then starts the remaining containers and optional extras.
+4. **Service start** – launches Gluetun first, waits for it to become healthy, then starts the asynchronous Proton port-forwarding worker (when enabled) and brings up the remaining containers and optional extras.
 5. **Summary** – prints URLs, credentials, and reminders such as updating *Arr download client hosts when split tunnel is active.
 
 Understanding this flow helps when troubleshooting: re-running the installer replays the entire pipeline and reconciles drift automatically.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,8 +6,8 @@ Edit `${ARRCONF_DIR}/userr.conf` to control how the installer renders `.env`, `d
 
 ## Configuration layers
 
-1. **Shell environment** – anything exported before running `./arr.sh` overrides every other source. Keep this for one-off tweaks or automation. Paths like `ARR_USERCONF_PATH` may be normalised to an absolute path while loading.
-2. **CLI flags** – run-scoped toggles (for example `./arr.sh --enable-caddy`) apply after the read-only guard. Use them for temporary changes; exported variables still win.
+1. **CLI flags** – run-scoped toggles (for example `./arr.sh --enable-caddy`) apply after the read-only guard. They override exported variables and `userr.conf`, so use them for temporary changes.
+2. **Shell environment** – anything exported before running `./arr.sh` still overrides `userr.conf` and defaults, but CLI flags are applied last. Paths like `ARR_USERCONF_PATH` may be normalised to an absolute path while loading.
 3. **`${ARRCONF_DIR}/userr.conf`** – your saved settings (defaults to `${ARR_DATA_ROOT}/${STACK}configs/userr.conf`). Keep it outside version control and rerun the installer after every edit.
 4. **`arrconf/userr.conf.defaults.sh`** – repo defaults.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,7 @@
 Edit `${ARRCONF_DIR}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and helper files. `ARR_DATA_ROOT` defaults to `~/srv`, so all generated files land under `~/srv/arr` unless you override the path. `./arr.sh` copies any exported environment variables, locks them read-only while your config loads, then reapplies them so CLI overrides always win. Before reading the file the installer looks for the first `userr.conf` under `${ARR_DATA_ROOT}` (depth 4) and then above the repo (for example `../userr.conf`); the chosen path appears in the preview table so you can confirm it.
 
 ## Configuration layers
+
 1. **Shell environment** – anything exported before running `./arr.sh` overrides every other source. Keep this for one-off tweaks or automation. Paths like `ARR_USERCONF_PATH` may be normalised to an absolute path while loading.
 2. **CLI flags** – run-scoped toggles (for example `./arr.sh --enable-caddy`) apply after the read-only guard. Use them for temporary changes; exported variables still win.
 3. **`${ARRCONF_DIR}/userr.conf`** – your saved settings (defaults to `${ARR_DATA_ROOT}/${STACK}configs/userr.conf`). Keep it outside version control and rerun the installer after every edit.
@@ -13,6 +14,7 @@ Edit `${ARRCONF_DIR}/userr.conf` to control how the installer renders `.env`, `d
 The installer prints a configuration table during preflight. Cancel with `Ctrl+C` if a value looks wrong, adjust `userr.conf`, and rerun.
 
 ## Core settings to review
+
 - **Network**
   - `LAN_IP`: set this to your host's private address before exposing ports.
   - `LOCALHOST_IP`: leave on loopback (`127.0.0.1`) so container healthchecks probe the right place.
@@ -43,21 +45,16 @@ The installer prints a configuration table during preflight. Cancel with `Ctrl+C
   - `ARR_PERMISSION_PROFILE`: `strict` (default) keeps secrets at `600`, data at `700`, and uses `umask 0077`. `collab` enables group write; set `PGID` to your shared group.
   - Optional overrides: `ARR_UMASK_OVERRIDE`, `ARR_DATA_DIR_MODE_OVERRIDE`, `ARR_NONSECRET_FILE_MODE_OVERRIDE`, `ARR_SECRET_FILE_MODE_OVERRIDE` for advanced tuning.
 
-## Working with overrides
+## Working with overrides / Verify resolved values
+
 1. Edit `${ARRCONF_DIR}/userr.conf` (or the path from `ARR_USERCONF_PATH`).
 2. Save the file and rerun:
    ```bash
    ./arr.sh --yes
    ```
+   Cancel before container startup if the preview looks wrong.
 3. Review the summary. Generated files (`.env`, `docker-compose.yml`, `Caddyfile`) should never be edited directly.
-
-## Verify
-- Show resolved values without applying changes:
-  ```bash
-  ./arr.sh --yes
-  ```
-  Cancel before container startup if the preview looks wrong.
-- Confirm preserved secrets remain in sync:
+4. Confirm preserved secrets remain in sync:
   ```bash
   grep -E '^QBT_(USER|PASS)=' .env
   ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,8 +51,9 @@ The installer prints a configuration table during preflight. Cancel with `Ctrl+C
 2. Save the file and rerun:
    ```bash
    ./arr.sh --yes
+   # Cancel before container startup if the preview looks wrong.
    ```
-   Cancel before container startup if the preview looks wrong.
+   
 3. Review the summary. Generated files (`.env`, `docker-compose.yml`, `Caddyfile`) should never be edited directly.
 4. Confirm preserved secrets remain in sync:
   ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,57 +2,54 @@
 
 # Configuration guide
 
-Edit `${ARRCONF_DIR}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and supporting files. `ARR_DATA_ROOT` defaults to `~/srv`, keeping generated assets under the historical data directory unless you override it. `./arr.sh` snapshots exported environment variables, marks them read-only before sourcing your config, and reapplies them afterwards so they continue to win over anything set inside `userr.conf` or the defaults. Before loading the file the installer searches the repo's parent directory for the first path named `userr.conf` (for example `../userr.conf` or `../overrides/site-a/userr.conf`) and uses that file; the same path is surfaced in the configuration preview so you can confirm which override will apply.
+Edit `${ARRCONF_DIR}/userr.conf` to control how the installer renders `.env`, `docker-compose.yml`, and helper files. `ARR_DATA_ROOT` defaults to `~/srv`, so all generated files land under `~/srv/arr` unless you override the path. `./arr.sh` copies any exported environment variables, locks them read-only while your config loads, then reapplies them so CLI overrides always win. Before reading the file the installer looks for the first `userr.conf` under `${ARR_DATA_ROOT}` (depth 4) and then above the repo (for example `../userr.conf`); the chosen path appears in the preview table so you can confirm it.
 
 ## Configuration layers
-1. **Shell environment** – anything exported before running `./arr.sh` overrides every other source (use for CI or one-off toggles). Values are made read-only while `userr.conf` loads and reasserted afterwards, except for internal read-only variables and normalized paths such as `ARR_USERCONF_PATH`, which may be canonicalised to an absolute path during startup.
-2. **CLI flags** – run-scoped toggles (for example `./arr.sh --enable-caddy`) apply after the read-only guard. Use them to temporarily override `userr.conf` without editing the file. Environment exports still win if both are present.
-3. **`${ARRCONF_DIR}/userr.conf`** – your persistent copy (defaults to `${ARR_DATA_ROOT}/${STACK}configs/userr.conf`). Keep it out of version control and rerun the installer after every edit.
-4. **`arrconf/userr.conf.defaults.sh`** – project defaults committed in the repo.
+1. **Shell environment** – anything exported before running `./arr.sh` overrides every other source. Keep this for one-off tweaks or automation. Paths like `ARR_USERCONF_PATH` may be normalised to an absolute path while loading.
+2. **CLI flags** – run-scoped toggles (for example `./arr.sh --enable-caddy`) apply after the read-only guard. Use them for temporary changes; exported variables still win.
+3. **`${ARRCONF_DIR}/userr.conf`** – your saved settings (defaults to `${ARR_DATA_ROOT}/${STACK}configs/userr.conf`). Keep it outside version control and rerun the installer after every edit.
+4. **`arrconf/userr.conf.defaults.sh`** – repo defaults.
 
 The installer prints a configuration table during preflight. Cancel with `Ctrl+C` if a value looks wrong, adjust `userr.conf`, and rerun.
 
 ## Core settings to review
 - **Network**
-  - `LAN_IP`: private address for the host; required before ports are exposed.
-  - `LOCALHOST_IP` must be loopback.
-    Healthchecks run inside containers. Set `LOCALHOST_IP` to a loopback address (`127.0.0.1`). If you point it at a LAN IP, some healthchecks will probe the wrong interface and flap. Example:
-
-    `LOCALHOST_IP=127.0.0.1`
-  - `LAN_DOMAIN_SUFFIX`: optional suffix for hostnames (default `home.arpa`). Needed for local DNS or Caddy.
-  - `SPLIT_VPN`: set `1` to run only qBittorrent inside Gluetun, or `0` to tunnel everything.
-  - `EXPOSE_DIRECT_PORTS`: leave at `1` for LAN-friendly URLs, or set `0` to keep services internal to Docker networking.
-  - `DNS_DISTRIBUTION_MODE`: choose `router` (default) to update DHCP Option 6, or `per-device` when pointing clients at the resolver manually.
-  - `ARR_PORT_CHECK_MODE`: `enforce` (default) fails fast on conflicts, `warn` prints notices, `skip` disables port validation (use sparingly), and `fix` attempts to stop conflicting listeners automatically before falling back to warn mode.
+  - `LAN_IP`: set this to your host's private address before exposing ports.
+  - `LOCALHOST_IP`: leave on loopback (`127.0.0.1`) so container healthchecks probe the right place.
+  - `LAN_DOMAIN_SUFFIX`: optional hostname suffix (default `home.arpa`) needed for local DNS and Caddy URLs.
+  - `SPLIT_VPN`: `1` routes only qBittorrent through Gluetun; `0` tunnels everything.
+  - `EXPOSE_DIRECT_PORTS`: keep at `1` for simple LAN URLs, or set `0` to hide services behind Docker networking.
+  - `DNS_DISTRIBUTION_MODE`: choose `router` to update DHCP Option 6 or `per-device` to set DNS on each client yourself.
+  - `ARR_PORT_CHECK_MODE`: `enforce` (default) stops on conflicts, `warn` prints notices, `skip` disables checks, and `fix` tries to stop known blockers before warning.
 - **Paths & storage**
-  - `ARR_DATA_ROOT`: top-level data directory (defaults to `~/srv`). Override it before running the installer if you want a different layout.
-  - `ARRCONF_DIR`: configuration directory for Proton credentials and overrides (defaults to `${ARR_DATA_ROOT}/${STACK}configs`).
-  - `DOWNLOADS_DIR`, `COMPLETED_DIR`, `MEDIA_DIR`, `TV_DIR`, `MOVIES_DIR`, `SUBS_DIR`: defaults live under `${ARR_DATA_ROOT}` (for example `${ARR_DATA_ROOT}/media` and `${ARR_DATA_ROOT}/media/Shows`), so update them in `userr.conf` to target your actual media drive.
-  - `ARR_LOG_DIR`: location for installer and helper logs if you prefer another disk.
+  - `ARR_DATA_ROOT`: base directory for everything (defaults to `~/srv`). Override it before the first run if you want a different location.
+  - `ARRCONF_DIR`: holds Proton credentials and overrides (defaults to `${ARR_DATA_ROOT}/${STACK}configs`).
+  - `DOWNLOADS_DIR`, `COMPLETED_DIR`, `MEDIA_DIR`, `TV_DIR`, `MOVIES_DIR`, `SUBS_DIR`: point these at your real storage; defaults live under `${ARR_DATA_ROOT}`.
+  - `ARR_LOG_DIR`: move logs if you prefer another disk.
 - **Credentials & preservation**
-  - `QBT_USER` / `QBT_PASS`: update after changing the WebUI login; rerun the installer to persist them.
-  - `GLUETUN_API_KEY`, `CADDY_BASIC_AUTH_USER`, `CADDY_BASIC_AUTH_HASH`: left blank by default so rotation helpers manage them.
-  - `QBT_AUTH_WHITELIST`: CIDRs that bypass the qBittorrent login (auto-populated with loopback and your LAN subnet).
+  - `QBT_USER` / `QBT_PASS`: keep these in sync with the WebUI. Rerun the installer after changes so `.env` updates automatically.
+  - `GLUETUN_API_KEY`, `CADDY_BASIC_AUTH_USER`, `CADDY_BASIC_AUTH_HASH`: leave blank; rotation helpers fill them in.
+  - `QBT_AUTH_WHITELIST`: CIDRs allowed to skip the qBittorrent login (loopback and your LAN are added automatically).
 - **Optional services**
-  - `ENABLE_CADDY`: `1` enables the HTTPS proxy on `CADDY_HTTP_PORT`/`CADDY_HTTPS_PORT` (defaults 80/443). Adjust those port variables if another web server is present.
-  - `ENABLE_LOCAL_DNS`: `1` runs the dnsmasq container for LAN hostnames; combine with `DNS_DISTRIBUTION_MODE` to control how clients learn the resolver. The installer records the runtime result in `LOCAL_DNS_STATE`/`LOCAL_DNS_STATE_REASON` so you can tell whether DNS actually started.
+  - `ENABLE_CADDY`: `1` enables HTTPS on `CADDY_HTTP_PORT`/`CADDY_HTTPS_PORT` (defaults 80/443).
+  - `ENABLE_LOCAL_DNS`: `1` starts the dnsmasq container. The installer reports the outcome in `LOCAL_DNS_STATE` and `LOCAL_DNS_STATE_REASON` so you can see if it actually launched.
   - `ENABLE_CONFIGARR`: `1` keeps Configarr managing Sonarr/Radarr settings.
-  - `SPLIT_VPN` and optional toggles such as `ENABLE_CADDY` can also be set per run with `./arr.sh` flags.
+  - Most toggles (including `SPLIT_VPN`) can also be set per run with CLI flags.
 - **VPN automation**
-  - `VPN_AUTO_RECONNECT_ENABLED`: monitor qBittorrent throughput and rotate Proton servers automatically.
-  - `VPN_SPEED_THRESHOLD_KBPS`, `VPN_CHECK_INTERVAL_MINUTES`, `VPN_CONSECUTIVE_CHECKS`: tune when reconnects trigger.
-  - `VPN_ALLOWED_HOURS_START` / `VPN_ALLOWED_HOURS_END`: restrict reconnect windows; set equal to permit 24/7 operation.
+  - `VPN_AUTO_RECONNECT_ENABLED`: runs the reconnect worker that watches qBittorrent speeds.
+  - `VPN_SPEED_THRESHOLD_KBPS`, `VPN_CHECK_INTERVAL_MINUTES`, `VPN_CONSECUTIVE_CHECKS`: tune how quickly reconnects fire.
+  - `VPN_ALLOWED_HOURS_START` / `VPN_ALLOWED_HOURS_END`: limit reconnects to certain hours; set the same number for 24/7.
 - **Permission profiles**
-  - `ARR_PERMISSION_PROFILE`: `strict` (default) keeps secrets at `600` and data at `700`. Switch to `collab` when multiple accounts need write access; set `PGID` to the shared group.
+  - `ARR_PERMISSION_PROFILE`: `strict` (default) keeps secrets at `600`, data at `700`, and uses `umask 0077`. `collab` enables group write; set `PGID` to your shared group.
   - Optional overrides: `ARR_UMASK_OVERRIDE`, `ARR_DATA_DIR_MODE_OVERRIDE`, `ARR_NONSECRET_FILE_MODE_OVERRIDE`, `ARR_SECRET_FILE_MODE_OVERRIDE` for advanced tuning.
 
 ## Working with overrides
-1. Edit `${ARRCONF_DIR}/userr.conf` (or the path set in `ARR_USERCONF_PATH`).
+1. Edit `${ARRCONF_DIR}/userr.conf` (or the path from `ARR_USERCONF_PATH`).
 2. Save the file and rerun:
    ```bash
    ./arr.sh --yes
    ```
-3. Review the printed summary. Generated files (`.env`, `docker-compose.yml`, `Caddyfile`) should never be edited directly.
+3. Review the summary. Generated files (`.env`, `docker-compose.yml`, `Caddyfile`) should never be edited directly.
 
 ## Verify
 - Show resolved values without applying changes:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -11,7 +11,7 @@ Any 64-bit Debian Bookworm host with roughly 4 CPU cores and 4 GB RAM works. Ras
 Use Proton VPN Plus or Unlimited. Those plans support port forwarding, which qBittorrent needs for good performance.
 
 ## Can I skip the DNS helper?
-Yes, but you must add host entries manually or set DNS per device. Following [Networking](networking.md) keeps the experience consistent.
+Yes, but you must add host entries manually or set DNS per device. Following [Networking](networking.md) keeps the experience consistent and avoids guesswork later.
 
 ## Where do I put my Proton credentials?
 Copy `arrconf/proton.auth.example` to `arrconf/proton.auth` and fill in `PROTON_USER` and `PROTON_PASS`. The installer enforces safe permissions automatically.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -19,7 +19,7 @@ Key terms referenced throughout the documentation.
 | **Port forwarding** | Proton VPN feature that assigns a TCP port so peers can reach qBittorrent through the VPN tunnel. |
 | **Private DNS / DoT** | Android feature for DNS-over-TLS. Leave it Off/Automatic so lookups stay inside your LAN. |
 
-If a term is unfamiliar, follow links in the other docs or run `man <term>` on Debian (for example, `man resolv.conf`).
+If a term is unfamiliar, follow links in the other docs or search the Debian manual pages (for example, `man resolv.conf`).
 
 ## Related topics
 - [Networking](networking.md)

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -48,7 +48,7 @@ Revert by setting `SPLIT_VPN=0` and rerunning the installer.
    ```
    Revert later with `./scripts/host-dns-rollback.sh`.
 3. Rerun the installer. The `local_dns` container serves `*.home.arpa` records and forwards other queries upstream.
-4. Point clients at the Pi as their primary DNS server (DHCP Option 6 or per-device settings). Keep a trusted public resolver listed as secondary.
+4. Point clients at the arrbash host as their primary DNS server (DHCP Option 6 or per-device settings). Keep a trusted public resolver listed as secondary.
 
 Check status with:
 ```bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -5,7 +5,7 @@
 Use these commands to run the installer safely, rotate credentials, and call helper scripts.
 
 ## Installer basics
-- `./arr.sh` is idempotent. Rerun it after editing `${ARRCONF_DIR}/userr.conf`; the script regenerates `.env`, `docker-compose.yml`, the Caddyfile, and helper assets before starting containers.
+- `./arr.sh` is idempotent. Rerun it after editing `${ARRCONF_DIR}/userr.conf`; the script regenerates `.env`, `docker-compose.yml`, the Caddyfile, and helper assets before starting containers. It only checks prerequisites, so install Docker and helper tools yourself first.
 - Key flags (combine as needed):
 
   ```bash

--- a/docs/sabnzbd.md
+++ b/docs/sabnzbd.md
@@ -1,8 +1,6 @@
 # SABnzbd Integration
 
-This document expands on the optional SABnzbd support shipped with the stack. It covers
-networking behaviour, environment overrides, helper tooling, and the preservation
-logic that keeps your API key and configuration safe across reruns.
+This document expands on the optional SABnzbd support shipped with the stack. It covers networking behaviour, environment overrides, helper tooling, and the preservation logic that keeps your API key and configuration safe across reruns.
 
 > **Quick toggle:** Run `./arr.sh --enable-sab --yes` to enable SABnzbd for a single
 > install without editing `${ARRCONF_DIR}/userr.conf`.
@@ -22,9 +20,7 @@ inside Gluetun).
 
 ## API Key Preservation
 
-The preservation layer parses `${ARR_DOCKER_DIR}/sab/config/sabnzbd.ini` on reruns.
-When `api_key = ...` is present and `.env` still contains the
-`REPLACE_WITH_SABNZBD_API_KEY` placeholder, the stack:
+The preservation layer parses `${ARR_DOCKER_DIR}/sab/config/sabnzbd.ini` on reruns. When `api_key = ...` is present and `.env` still contains the `REPLACE_WITH_SABNZBD_API_KEY` placeholder, the stack:
 
 1. Takes a timestamped backup of `sabnzbd.ini` (`sabnzbd.ini.bak-YYYYmmdd-HHMMSS`).
 2. Hydrates `SABNZBD_API_KEY` in-memory and records a preservation note for the
@@ -37,8 +33,7 @@ file contains a `SABNZBD_API_KEY` entry. Hydrated keys replace the
 `REPLACE_WITH_SABNZBD_API_KEY` placeholder automatically; existing non-placeholder
 values are left untouched.
 
-If you manually rotate the API key, rerun `./arr.sh --yes` after SAB has
-written the change; the installer will detect and capture the new value.
+If you manually rotate the API key, rerun `./arr.sh --yes` after SAB has written the change so the installer can capture the new value.
 
 ## Healthcheck Improvements
 
@@ -85,30 +80,10 @@ SABNZBD_HOST="sabnzbd"     # qBittorrent now listens on 8082 inside Gluetun
 
 ## Helper Script
 
-`scripts/sab-helper.sh` ships with the stack and is automatically copied to
-`${ARR_STACK_DIR}/scripts/sab-helper.sh` when SAB is enabled. Core commands:
-
-```bash
-./scripts/sab-helper.sh version   # Prints SAB version via the public API endpoint
-./scripts/sab-helper.sh status    # Summarises queue state and download speed
-./scripts/sab-helper.sh queue     # Raw queue JSON (requires API key)
-./scripts/sab-helper.sh add-file <path/to/file.nzb>
-./scripts/sab-helper.sh add-url <https://example/nzb>
-```
-
-After `./arr.sh --refresh-aliases`, the shell also exposes `sab-logs`,
-`sab-shell`, and `open-sab` convenience aliases.
-
-If SAB is disabled the helper prints a warning and exits gracefully. Ensure
-`SABNZBD_HOST`, `SABNZBD_PORT`, and `SABNZBD_API_KEY` are correct before using upload commands.
-The helper will still report the SAB version even when the API key is not yet
-configured, aligning with the new compose healthcheck.
+`scripts/sab-helper.sh` ships with the stack and is automatically copied to `${ARR_STACK_DIR}/scripts/sab-helper.sh` when SAB is enabled. Run it with `--help` for a full command list; the most common tasks are `status`, `add-file`, and `add-url`. After `./arr.sh --refresh-aliases`, the shell also exposes `sab-logs`, `sab-shell`, and `open-sab` convenience aliases. If SAB is disabled the helper prints a warning and exits gracefully. Ensure `SABNZBD_HOST`, `SABNZBD_PORT`, and `SABNZBD_API_KEY` are correct before using upload commands. The helper will still report the SAB version even when the API key is not yet configured, matching the compose healthcheck.
 
 ## Deferred Features
 
-`SABNZBD_CATEGORY` is passed through to helper uploads today but the stack does
-not yet manage SAB categories automatically. Future hardening work will also look
-at container resource limits (CPU, memory) and read-only filesystems; the compose
-output includes a commented NOTE as a reminder.
+`SABNZBD_CATEGORY` is passed through to helper uploads today but the stack does not yet manage SAB categories automatically. Future hardening work will also look at container resource limits (CPU, memory) and read-only filesystems; the compose output includes a commented note as a reminder.
 
 For troubleshooting tips or examples, visit the main [Operations guide](operations.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,7 +5,7 @@
 Keep the deployment private to your LAN and rotate credentials regularly.
 
 ## Secrets and permissions
-- Leave `ARR_PERMISSION_PROFILE=strict` unless you require collaborative write access. Secrets stay at mode `600`, data directories at `700`, and the installer enforces `umask 0077`.
+- Leave `ARR_PERMISSION_PROFILE=strict` unless you need collaborative write access. Secrets stay at mode `600`, data directories at `700`, and the installer enforces `umask 0077`.
 - When using the `collab` profile, set `PGID` to the shared storage group so write access is limited to expected members.
 - Never commit `arrconf/proton.auth`, `.env`, or other generated files to version control. The installer keeps permissions tight automatically.
 
@@ -17,7 +17,7 @@ Keep the deployment private to your LAN and rotate credentials regularly.
 
 ## Network exposure
 - Bind the stack to a private `LAN_IP` and avoid forwarding raw service ports through your router. Use Caddy with strong credentials if you require remote access.
-- When local DNS is enabled, ensure only trusted clients point at the Pi. Keep a fallback public resolver in DHCP to avoid outages if the Pi is offline.
+- When local DNS is enabled, ensure only trusted clients point at the arrbash host. Keep a fallback public resolver in DHCP to avoid outages if the host is offline.
 - Enabling local DNS backs up `/etc/docker/daemon.json`, merges in `{ "userland-proxy": false }`, and requires a Docker restart before the change applies (use `scripts/host-dns-rollback.sh` to undo it).
 - Verify open ports regularly:
   ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,7 +6,7 @@ Follow these checks when services fail to start, DNS stops resolving, or VPN hel
 
 ## DNS and HTTPS issues
 ### `ERR_NAME_NOT_RESOLVED`
-- Applies only when local DNS is enabled. Ensure clients point at the Pi first (DHCP Option 6 or per-device settings). See [Networking](networking.md) for setup guidance.
+- Applies only when local DNS is enabled. Ensure clients point at the arrbash host first (DHCP Option 6 or per-device settings). See [Networking](networking.md) for setup guidance.
 - Verify:
   ```bash
   nslookup qbittorrent.${LAN_DOMAIN_SUFFIX:-home.arpa}

--- a/docs/version-management.md
+++ b/docs/version-management.md
@@ -40,7 +40,7 @@ The stack pins each image to a tested tag. Registries occasionally remove old ma
 ## Recover from `manifest unknown`
 1. Repair the generated `.env`:
    ```bash
-   ${ARR_STACK_DIR}/scripts/fix-versions.sh
+   ./scripts/fix-versions.sh
    ```
 2. Rerun the installer:
    ```bash

--- a/docs/version-management.md
+++ b/docs/version-management.md
@@ -40,7 +40,7 @@ The stack pins each image to a tested tag. Registries occasionally remove old ma
 ## Recover from `manifest unknown`
 1. Repair the generated `.env`:
    ```bash
-   ./scripts/fix-versions.sh
+   "${ARR_STACK_DIR}/scripts/fix-versions.sh"
    ```
 2. Rerun the installer:
    ```bash


### PR DESCRIPTION
### **User description**
## Summary
- clarify the README quick start so it reflects the installer’s dependency checks and trims duplicated SAB helper instructions
- refresh the configuration, networking, security, troubleshooting, and supporting docs with consistent host terminology and current workflow details
- streamline SABnzbd and version management guidance to reference the bundled helpers instead of repeating command lists

## Testing
- ./arr.sh --help | head -n 20

------
https://chatgpt.com/codex/tasks/task_e_68e3a09e549483298d52edd52467e409


___

### **PR Type**
Documentation


___

### **Description**
- Sync README quick start with installer behavior

- Update configuration and networking docs with consistent terminology

- Streamline SABnzbd guidance to reference bundled helpers

- Refresh troubleshooting and security docs with current workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md"] --> B["Quick start clarity"]
  C["Configuration docs"] --> D["Consistent terminology"]
  E["SABnzbd guide"] --> F["Helper script references"]
  G["Supporting docs"] --> H["Current workflow alignment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update quick start and SABnzbd sections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>architecture.md</strong><dd><code>Replace Pi references with host terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.md</strong><dd><code>Streamline configuration layer explanations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180">+28/-31</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>faq.md</strong><dd><code>Minor wording improvements for clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-57cdcc6b6701a7ce3b3a8f8c0366e0e611e6fb1a1b8dd7cd29e3263b3e064c8b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>glossary.md</strong><dd><code>Update manual page reference format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-c42a05dfff7873800ca86ea805b61b7a52aefb8f9462d0e4adb5753a037d4bfa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>networking.md</strong><dd><code>Replace Pi references with host terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-b053012ac3d8fcefac4db4a31991bf84d456448472e19d5116d36ff6206fbfc2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>operations.md</strong><dd><code>Clarify installer prerequisite behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-ad74991b96593fdee570962fc5b1e319080abd55e16614f556f74b7de8fd02d1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sabnzbd.md</strong><dd><code>Consolidate helper script documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-3bc8e67c97e745fca1724afdace86a4d6ced00aba977b9783873a8e20aa92442">+5/-30</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>security.md</strong><dd><code>Replace Pi references with host terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-2c506cc756a5333f8fb5acb850d443980706602048f9ddb3dc515abacbfbce6a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>troubleshooting.md</strong><dd><code>Replace Pi references with host terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>version-management.md</strong><dd><code>Fix script path reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbkii/arrbash/pull/66/files#diff-1cf00b5dc8ea5e6fdc8ccc3bb954e5ea64de1e1cb39370f168bbadbe10659686">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Pointed networking/DNS guidance to the arrbash host instead of the Pi.
  - Clarified installer flow: waits for VPN health, then starts optional Proton port‑forwarding before remaining services.
  - Reworked configuration docs: default paths, override discovery, layering, core settings, credentials, optional services and VPN behaviour.
  - Simplified override usage and verification steps; improved examples and preview flow.
  - Noted prerequisite installs in operations.
  - Streamlined SABnzbd instructions and healthcheck notes.
  - Refined FAQ, glossary, security, troubleshooting wording and adjusted version-repair command path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->