### PR TITLE
Align trace log naming with primary log file

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1003,7 +1003,12 @@ init_logging() {
   ensure_dir_mode "$log_dir" "$DATA_DIR_MODE"
 
   local timestamp
-  timestamp="$(date +%Y%m%d-%H%M%S)"
+  if [[ -n "${ARR_LOG_TIMESTAMP:-}" ]]; then
+    timestamp="${ARR_LOG_TIMESTAMP}"
+  else
+    timestamp="$(date +%Y%m%d-%H%M%S)"
+    export ARR_LOG_TIMESTAMP="$timestamp"
+  fi
   LOG_FILE="${log_dir}/${STACK}-${timestamp}.log"
 
   : >"$LOG_FILE"

--- a/scripts/logging.sh
+++ b/scripts/logging.sh
@@ -1,0 +1,82 @@
+# shellcheck shell=bash
+# Opt-in structured xtrace to file with basic secret-masking.
+# Usage:
+#   export ARR_TRACE=1                       # or pass --trace to arr.sh (see patch)
+#   export ARR_TRACE_DEBUG=0|1               # (optional) also log each simple command via DEBUG trap
+#   export ARR_TRACE_FILE=/path/to/log       # (optional) override default
+#   export ARR_TRACE_MASK_RE='regex|to|mask' # (optional) add extra masking patterns
+
+arr_trace_start() {
+  local base_log="${LOG_FILE:-}" trace_file=""
+
+  if [[ -z "$base_log" ]]; then
+    local log_dir timestamp stack_name
+    if [[ -n "${ARR_LOG_DIR:-}" ]]; then
+      log_dir="${ARR_LOG_DIR%/}"
+    elif [[ -n "${ARR_STACK_DIR:-}" ]]; then
+      log_dir="${ARR_STACK_DIR%/}/logs"
+    else
+      log_dir="${REPO_ROOT:-.}/logs"
+    fi
+
+    if declare -f ensure_dir_mode >/dev/null 2>&1; then
+      ensure_dir_mode "$log_dir" "${DATA_DIR_MODE:-700}"
+    else
+      mkdir -p "$log_dir"
+    fi
+
+    timestamp="${ARR_LOG_TIMESTAMP:-}"
+    if [[ -z "$timestamp" ]]; then
+      timestamp="$(date +%Y%m%d-%H%M%S)"
+      export ARR_LOG_TIMESTAMP="$timestamp"
+    fi
+
+    stack_name="${STACK:-arr}"
+    base_log="${log_dir}/${stack_name}-${timestamp}.log"
+  fi
+
+  if [[ "$base_log" == *.log ]]; then
+    trace_file="${base_log%.log}-trace.log"
+  else
+    trace_file="${base_log}-trace.log"
+  fi
+
+  export ARR_TRACE_FILE="${ARR_TRACE_FILE:-$trace_file}"
+
+  local base_mask='([Pp]assword|[Tt]oken|[Ss]ecret|[Aa]pi[_-]?[Kk]ey)=[^[:space:]]+|Authorization:[[:space:]]*Basic[[:space:]]+[A-Za-z0-9+/=]+'
+  local mask="${ARR_TRACE_MASK_RE:+${ARR_TRACE_MASK_RE}|}${base_mask}"
+
+  exec {__arr_trace_fd}> >(
+    if [[ -n "$mask" ]]; then
+      sed -u -E "s/${mask}/[REDACTED]/g" >> "$ARR_TRACE_FILE"
+    else
+      cat >> "$ARR_TRACE_FILE"
+    fi
+  )
+
+  export BASH_XTRACEFD=$__arr_trace_fd
+
+  if [[ "${BASH_VERSINFO[0]:-0}" -ge 5 ]]; then
+    export PS4='+ [${EPOCHREALTIME}] [${BASH_SOURCE##*/}:${LINENO}] ${FUNCNAME[0]:-main}() '
+  else
+    export PS4='+ [TRACE] [${BASH_SOURCE##*/}:${LINENO}] ${FUNCNAME[0]:-main}() '
+  fi
+
+  set -o xtrace
+
+  if [[ "${ARR_TRACE_DEBUG:-0}" == "1" ]]; then
+    trap 'printf "%s [%s:%s] %s\n" "$(date -Iseconds)" "${BASH_SOURCE##*/}" "${LINENO}" "$BASH_COMMAND" >&$__arr_trace_fd' DEBUG
+    set -o functrace
+  fi
+
+  trap 'arr_trace_stop' EXIT
+}
+
+arr_trace_stop() {
+  { set +o xtrace; } 2>/dev/null || true
+  trap - DEBUG || true
+  if [[ -n "${__arr_trace_fd:-}" ]]; then
+    exec {__arr_trace_fd}>&- || true
+    unset __arr_trace_fd
+  fi
+}

--- a/scripts/logging.sh
+++ b/scripts/logging.sh
@@ -43,7 +43,7 @@ arr_trace_start() {
 
   export ARR_TRACE_FILE="${ARR_TRACE_FILE:-$trace_file}"
 
-  local base_mask='([Pp]assword|[Tt]oken|[Ss]ecret|[Aa]pi[_-]?[Kk]ey)=[^[:space:]]+|Authorization:[[:space:]]*Basic[[:space:]]+[A-Za-z0-9+/=]+'
+  local base_mask='([Pp]assword|[Tt]oken|[Ss]ecret|[Aa]pi[_-]?[Kk]ey|[Aa]ccess[_-]?[Tt]oken|[Aa]uth|[Ss]ession|[Jj]wt)=[^[:space:]]+|Authorization:[[:space:]]*Basic[[:space:]]+[A-Za-z0-9+/=]+|Authorization:[[:space:]]*Bearer[[:space:]]+[A-Za-z0-9\-._~+/]+=*|Cookie:[[:space:]]*[^;[:space:]]+'
   local mask="${ARR_TRACE_MASK_RE:+${ARR_TRACE_MASK_RE}|}${base_mask}"
 
   exec {__arr_trace_fd}> >(

--- a/scripts/logging.sh
+++ b/scripts/logging.sh
@@ -65,7 +65,11 @@ arr_trace_start() {
   set -o xtrace
 
   if [[ "${ARR_TRACE_DEBUG:-0}" == "1" ]]; then
-    trap 'printf "%s [%s:%s] %s\n" "$(date -Iseconds)" "${BASH_SOURCE##*/}" "${LINENO}" "$BASH_COMMAND" >&$__arr_trace_fd' DEBUG
+    if [[ "${BASH_VERSINFO[0]:-0}" -ge 5 ]]; then
+      trap 'printf "%s [%s:%s] %s\n" "${EPOCHREALTIME}" "${BASH_SOURCE##*/}" "${LINENO}" "$BASH_COMMAND" >&$__arr_trace_fd' DEBUG
+    else
+      trap 'printf "%s [%s:%s] %s\n" "${SECONDS}" "${BASH_SOURCE##*/}" "${LINENO}" "$BASH_COMMAND" >&$__arr_trace_fd' DEBUG
+    fi
     set -o functrace
   fi
 


### PR DESCRIPTION
### **User description**
## Summary
- add a logging helper that writes masked bash xtrace output to per-run log files
- allow arr.sh to source the helper, enable tracing via --trace or ARR_TRACE, and surface the log path on errors
- align trace log file naming with the primary log path and timestamp so trace runs follow the existing log naming scheme

## Testing
- bash -n arr.sh
- bash -n scripts/logging.sh
- bash -n scripts/common.sh

------
https://chatgpt.com/codex/tasks/task_e_68e3ab117b8c8329aaecfb1528d9e01b


___

### **PR Type**
Enhancement


___

### **Description**
- Add opt-in bash xtrace logging with secret masking

- Align trace log naming with primary log timestamps

- Enable tracing via --trace flag or ARR_TRACE variable

- Display trace log path on errors for debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["arr.sh --trace"] --> B["logging.sh"]
  B --> C["trace file creation"]
  C --> D["masked xtrace output"]
  E["error handler"] --> F["display trace path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>arr.sh</strong><dd><code>Add trace option and error reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

arr.sh

<ul><li>Add <code>--trace</code> command line option support<br> <li> Source new logging.sh module for trace functionality<br> <li> Display trace log path in error handler<br> <li> Initialize tracing when ARR_TRACE=1 is set</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/69/files#diff-90d48d4031c48b3c84f710701a342ddb7318b8a17c35fce4ac02f2a765dfb3d5">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>common.sh</strong><dd><code>Share log timestamp across modules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/common.sh

<ul><li>Export <code>ARR_LOG_TIMESTAMP</code> for consistent naming<br> <li> Reuse existing timestamp if already set</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/69/files#diff-b23204e92f793e233cf28605758e6f1d4849830577492c85f00593f977527e27">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logging.sh</strong><dd><code>New xtrace logging with secret masking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/logging.sh

<ul><li>Implement <code>arr_trace_start()</code> and <code>arr_trace_stop()</code> functions<br> <li> Add secret masking for passwords, tokens, and API keys<br> <li> Create trace files aligned with primary log naming<br> <li> Support optional debug tracing and custom mask patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/69/files#diff-99e7f50a636b4d17be87965489e6021e7eb3b47228f3838001c74a3eb6cd31ff">+82/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

