### PR TITLE
fix: ensure generated helper scripts are executable

### DIFF
--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -474,7 +474,7 @@ DIAG
   diag_dir_escaped=${diag_dir_escaped//|/\|}
   sed -e "s|__ARR_STACK_DIR__|${diag_dir_escaped}|g" "$diag_script" >"$diag_tmp"
   mv "$diag_tmp" "$diag_script"
-  ensure_file_mode "$diag_script" 755 || chmod 755 "$diag_script"
+  ensure_file_mode "$diag_script" 755
   msg "Diagnostic script: ${diag_script}"
 }
 

--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -335,7 +335,8 @@ install_aliases() {
     fi
   fi
 
-  local diag_script="${ARR_STACK_DIR}/diagnose-vpn.sh"
+  local diag_script="${ARR_STACK_DIR}/scripts/diagnose-vpn.sh"
+  ensure_dir_mode "${ARR_STACK_DIR}/scripts" 755
   cat >"$diag_script" <<'DIAG'
 #!/bin/bash
 set -euo pipefail

--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -356,9 +356,10 @@ install_aliases() {
   else
     warn "Reload your shell configuration to activate ARR aliases"
   fi
-
-  local diag_script="${ARR_STACK_DIR}/scripts/diagnose-vpn.sh"
+  
   ensure_dir_mode "${ARR_STACK_DIR}/scripts" 755
+  
+  local diag_script="${ARR_STACK_DIR}/scripts/diagnose-vpn.sh"
   cat >"$diag_script" <<'DIAG'
 #!/bin/bash
 set -euo pipefail
@@ -473,7 +474,7 @@ DIAG
   diag_dir_escaped=${diag_dir_escaped//|/\|}
   sed -e "s|__ARR_STACK_DIR__|${diag_dir_escaped}|g" "$diag_script" >"$diag_tmp"
   mv "$diag_tmp" "$diag_script"
-  chmod 755 "$diag_script"
+  ensure_file_mode "$diag_script" 755 || chmod 755 "$diag_script"
   msg "Diagnostic script: ${diag_script}"
 }
 

--- a/scripts/files.sh
+++ b/scripts/files.sh
@@ -2213,7 +2213,7 @@ sync_gluetun_library() {
   ensure_dir_mode "$ARR_STACK_DIR/scripts" 755
 
   cp "${REPO_ROOT}/scripts/gluetun.sh" "$ARR_STACK_DIR/scripts/gluetun.sh"
-  ensure_file_mode "$ARR_STACK_DIR/scripts/gluetun.sh" 644
+  ensure_file_mode "$ARR_STACK_DIR/scripts/gluetun.sh" 755
 }
 
 # Syncs VPN auto-reconnect scripts with executable permissions into the stack
@@ -2223,7 +2223,7 @@ sync_vpn_auto_reconnect_assets() {
   ensure_dir_mode "$ARR_STACK_DIR/scripts" 755
 
   cp "${REPO_ROOT}/scripts/vpn-auto-reconnect.sh" "$ARR_STACK_DIR/scripts/vpn-auto-reconnect.sh"
-  ensure_file_mode "$ARR_STACK_DIR/scripts/vpn-auto-reconnect.sh" 644
+  ensure_file_mode "$ARR_STACK_DIR/scripts/vpn-auto-reconnect.sh" 755
 
   cp "${REPO_ROOT}/scripts/vpn-auto-reconnect-daemon.sh" "$ARR_STACK_DIR/scripts/vpn-auto-reconnect-daemon.sh"
   ensure_file_mode "$ARR_STACK_DIR/scripts/vpn-auto-reconnect-daemon.sh" 755


### PR DESCRIPTION
### **User description**
## Summary
- ensure the generated Gluetun and VPN auto-reconnect helpers are installed with executable permissions
- place the diagnose-vpn helper under the stack scripts directory and enforce executable-friendly permissions there

## Impact
- generated helper scripts can be executed immediately without manual chmod adjustments
- diagnose-vpn.sh now lives alongside the rest of the stack helper scripts for easier discovery

## Actions
- none

## Testing
- shellcheck scripts/files.sh scripts/aliases.sh *(warnings: existing unused-variable and literal-expansion notices)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b4b60e6c8329845bd5185c9ed13b


___

### **PR Type**
Bug fix


___

### **Description**
- Set executable permissions (755) for generated helper scripts

- Move diagnose-vpn.sh to scripts directory for consistency

- Ensure scripts directory has proper permissions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Helper Scripts"] --> B["Set 755 Permissions"]
  C["diagnose-vpn.sh"] --> D["Move to scripts/"]
  B --> E["Executable Scripts"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aliases.sh</strong><dd><code>Relocate diagnose script to scripts directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/aliases.sh

<ul><li>Move <code>diagnose-vpn.sh</code> from stack root to <code>scripts/</code> subdirectory<br> <li> Add <code>ensure_dir_mode</code> call to set proper permissions on scripts <br>directory</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/71/files#diff-fd9a048f22b2d42a088ee6c69ebeb748e826a6608c39cc1ee4780b079e89f0c4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>files.sh</strong><dd><code>Set executable permissions for helper scripts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/files.sh

<ul><li>Change file permissions from 644 to 755 for <code>gluetun.sh</code><br> <li> Change file permissions from 644 to 755 for <code>vpn-auto-reconnect.sh</code><br> <li> Ensure helper scripts are executable after installation</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/71/files#diff-a33e361169c3c851e6a6efdfc11feae384b52a28e475fb16ef6eb80241299b6f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

