### PR TITLE
chore: standardise helper usage and prune dev-only runtime code

### DIFF
--- a/arrconf/userr.conf.defaults.sh
+++ b/arrconf/userr.conf.defaults.sh
@@ -5,26 +5,6 @@
 # behave predictably when the user configuration runs afterwards.
 # Override these in ${ARRCONF_DIR}/userr.conf (git-ignored; defaults to ${ARR_DATA_ROOT}/${STACK}configs/userr.conf where ARR_DATA_ROOT defaults to ~/srv).
 
-# Guard helpers for shells that source these defaults alongside other scripts
-if ! declare -f arr_var_is_readonly >/dev/null 2>&1; then
-  arr_var_is_readonly() {
-    local var="$1"
-    local declaration=""
-
-    if ! declaration=$(declare -p "$var" 2>/dev/null); then
-      return 1
-    fi
-
-    case $declaration in
-      declare\ -r*)
-        return 0
-        ;;
-    esac
-
-    return 1
-  }
-fi
-
 # Base paths
 STACK="${STACK:-arr}"
 STACK_UPPER="${STACK_UPPER:-${STACK^^}}"
@@ -52,7 +32,7 @@ ARR_INSTALL_LOG="${ARR_INSTALL_LOG:-${ARR_LOG_DIR}/${STACK}-install.log}"
 ARR_COLOR_OUTPUT="${ARR_COLOR_OUTPUT:-1}"
 
 # File/dir permissions (strict keeps secrets 600/700, collab enables group read/write 660/770)
-if ! arr_var_is_readonly ARR_PERMISSION_PROFILE; then
+if ! declare -f arr_var_is_readonly >/dev/null 2>&1 || ! arr_var_is_readonly ARR_PERMISSION_PROFILE; then
   ARR_PERMISSION_PROFILE="${ARR_PERMISSION_PROFILE:-strict}"
 fi
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -67,6 +67,18 @@ arr_resolve_color_output() {
 
 arr_resolve_color_output
 
+# Determines if a shell variable is readonly to avoid clobbering host overrides
+arr_var_is_readonly() {
+  local varname="$1"
+  local declaration=""
+
+  if ! declaration=$(declare -p -- "$varname" 2>/dev/null); then
+    return 1
+  fi
+
+  [[ ${declaration} == declare\ -*r* ]]
+}
+
 # Checks command availability without emitting output (used for optional deps)
 have_command() {
   command -v "$1" >/dev/null 2>&1

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -1,25 +1,5 @@
 # shellcheck shell=bash
 
-if ! declare -f arr_var_is_readonly >/dev/null 2>&1; then
-  arr_var_is_readonly() {
-    # Determines if a shell variable is readonly to avoid clobbering host overrides
-    local var="$1"
-    local declaration=""
-
-    if ! declaration=$(declare -p "$var" 2>/dev/null); then
-      return 1
-    fi
-
-    case $declaration in
-      declare\ -r*)
-        return 0
-        ;;
-    esac
-
-    return 1
-  }
-fi
-
 # Seeds global defaults, handling collaborative profile toggles and legacy overrides
 arr_setup_defaults() {
   local previous_stack_dir="${ARR_STACK_DIR:-}"

--- a/scripts/vpn-auto-reconnect.sh
+++ b/scripts/vpn-auto-reconnect.sh
@@ -64,43 +64,40 @@ vpn_auto_reconnect_state_dir() {
     return
   fi
 
+  local root=""
+  root="$(vpn_auto_gluetun_root 2>/dev/null || printf '')"
+  if [[ -z "$root" ]]; then
+    return 1
+  fi
+
+  printf '%s/auto-reconnect' "$root"
+}
+
+# Returns path to persisted state.json for reconnect worker
 vpn_auto_reconnect_state_file() {
   local dir
   dir="$(vpn_auto_reconnect_state_dir 2>/dev/null)" || return 1
   printf '%s/state.json' "$dir"
 }
 
+# Cookie jar used for qBittorrent API sessions
 vpn_auto_reconnect_cookie_file() {
   local dir
   dir="$(vpn_auto_reconnect_state_dir 2>/dev/null)" || return 1
   printf '%s/session.cookie' "$dir"
 }
 
+# History log tracking reconnect attempts and outcomes
 vpn_auto_reconnect_history_file() {
   local dir
   dir="$(vpn_auto_reconnect_state_dir 2>/dev/null)" || return 1
   printf '%s/history.log' "$dir"
 }
 
-# Returns path to persisted state.json for reconnect worker
-vpn_auto_reconnect_state_file() {
-  printf '%s/state.json' "$(vpn_auto_reconnect_state_dir)"
-}
-
 # Path to human-readable status JSON stored alongside stack root
 vpn_auto_reconnect_status_file() {
   local stack_dir="${ARR_STACK_DIR:-${REPO_ROOT:-$(pwd)}}"
   printf '%s/.vpn-auto-reconnect-status.json' "${stack_dir%/}"
-}
-
-# Cookie jar used for qBittorrent API sessions
-vpn_auto_reconnect_cookie_file() {
-  printf '%s/session.cookie' "$(vpn_auto_reconnect_state_dir)"
-}
-
-# History log tracking reconnect attempts and outcomes
-vpn_auto_reconnect_history_file() {
-  printf '%s/history.log' "$(vpn_auto_reconnect_state_dir)"
 }
 
 if ! declare -f pf_state_lock_file >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- source the shared helper library earlier in `arr.sh`, rely on the canonical `arr_var_is_readonly`, and drop the ARR_ALLOW_MISSING_MODULES escape hatch
- remove duplicated readonly helpers from defaults so config loading always defers to the shared implementation while keeping compatibility guards
- restore the vpn auto-reconnect state helpers to a single canonical implementation that resolves paths through the shared helpers

## Testing
- `shellcheck -x arr.sh scripts/common.sh scripts/defaults.sh scripts/vpn-auto-reconnect.sh arrconf/userr.conf.defaults.sh`
- `./arr.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_68e4e98e40888329a2756e2a8f546dd3