### PR TITLE
fix(installer): simplify proton +pmp enforcement

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1442,13 +1442,17 @@ unescape_env_value_from_compose() {
 
   value="${value//$'\r'/}" # Normalize line endings
 
-  if [[ "$value" =~ ^".*"$ ]]; then
-    value="${value:1:${#value}-2}"
-    value="${value//\$\$/${sentinel}}"
-    value="$(printf '%b' "$value")"
-    value="${value//${sentinel}/\$}"
-    printf '%s' "$value"
-    return
+  if (( ${#value} >= 2 )); then
+    local first_char="${value:0:1}"
+    local last_char="${value: -1}"
+    if [[ "$first_char" == '"' && "$last_char" == '"' ]]; then
+      value="${value:1:${#value}-2}"
+      value="${value//\$\$/${sentinel}}"
+      value="$(printf '%b' "$value")"
+      value="${value//${sentinel}/\$}"
+      printf '%s' "$value"
+      return
+    fi
   fi
 
   value="${value//\$\$/${sentinel}}"

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -33,14 +33,15 @@ load_proton_credentials() {
   if [[ -z "$PROTON_USER_VALUE" || -z "$PROTON_PASS_VALUE" ]]; then
     die "Missing or empty PROTON_USER/PROTON_PASS in ${proton_file}"
   fi
-
+  
   OPENVPN_USER_VALUE="$PROTON_USER_VALUE"
-  PROTON_USER_PMP_ADDED=0
+  OPENVPN_USER_VALUE="$(trim_string "$OPENVPN_USER_VALUE")"
   if [[ "$OPENVPN_USER_VALUE" != *"+pmp" ]]; then
     OPENVPN_USER_VALUE+="+pmp"
     PROTON_USER_PMP_ADDED=1
+  else
+    PROTON_USER_PMP_ADDED=0
   fi
-
   : "$PROTON_USER_PMP_ADDED"
 }
 

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -24,27 +24,23 @@ validate_proton_creds() {
 load_proton_credentials() {
   local proton_file="${ARRCONF_DIR}/proton.auth"
 
-  PROTON_USER_VALUE=""
-  PROTON_PASS_VALUE=""
-  OPENVPN_USER_VALUE=""
-  PROTON_USER_PMP_ADDED=0
+  PROTON_USER_VALUE="$(get_env_kv PROTON_USER "$proton_file" 2>/dev/null || printf '')"
+  PROTON_PASS_VALUE="$(get_env_kv PROTON_PASS "$proton_file" 2>/dev/null || printf '')"
 
-  if [[ -f "$proton_file" ]]; then
-    PROTON_USER_VALUE="$(grep '^PROTON_USER=' "$proton_file" | head -n1 | cut -d= -f2- | tr -d '\r' || true)"
-    PROTON_PASS_VALUE="$(grep '^PROTON_PASS=' "$proton_file" | head -n1 | cut -d= -f2- | tr -d '\r' || true)"
-  fi
+  PROTON_USER_VALUE="${PROTON_USER_VALUE//$'\r'/}"
+  PROTON_PASS_VALUE="${PROTON_PASS_VALUE//$'\r'/}"
 
   if [[ -z "$PROTON_USER_VALUE" || -z "$PROTON_PASS_VALUE" ]]; then
     die "Missing or empty PROTON_USER/PROTON_PASS in ${proton_file}"
   fi
 
-  local enforced
-  enforced="${PROTON_USER_VALUE%+pmp}+pmp"
-  if [[ "$enforced" != "$PROTON_USER_VALUE" ]]; then
+  OPENVPN_USER_VALUE="$PROTON_USER_VALUE"
+  PROTON_USER_PMP_ADDED=0
+  if [[ "$OPENVPN_USER_VALUE" != *"+pmp" ]]; then
+    OPENVPN_USER_VALUE+="+pmp"
     PROTON_USER_PMP_ADDED=1
   fi
 
-  OPENVPN_USER_VALUE="$enforced"
   : "$PROTON_USER_PMP_ADDED"
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- simplify the Proton credential loader by reading values once and only appending +pmp when required

## Testing
- shellcheck -x scripts/config.sh

------
https://chatgpt.com/codex/tasks/task_e_68e52448d36483299926d41ab14ad70f


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Simplify Proton credential loading logic

- Fix string handling in environment value parsing

- Improve +pmp suffix enforcement for Proton usernames

- Add safer bounds checking for quoted strings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["proton.auth file"] --> B["load_proton_credentials()"]
  B --> C["get_env_kv() parsing"]
  C --> D["normalize line endings"]
  D --> E["enforce +pmp suffix"]
  E --> F["OPENVPN_USER_VALUE"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.sh</strong><dd><code>Safer string bounds checking in unescape function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/common.sh

<ul><li>Add bounds checking before accessing string characters<br> <li> Improve quoted string detection with explicit first/last character <br>checks<br> <li> Maintain existing escape sequence processing logic</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/83/files#diff-b23204e92f793e233cf28605758e6f1d4849830577492c85f00593f977527e27">+11/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.sh</strong><dd><code>Streamline Proton credential loading and +pmp enforcement</code></dd></summary>
<hr>

scripts/config.sh

<ul><li>Replace grep-based parsing with <code>get_env_kv()</code> function calls<br> <li> Simplify +pmp suffix enforcement logic using string operations<br> <li> Remove redundant variable initialization and intermediate processing<br> <li> Consolidate line ending normalization</ul>


</details>


  </td>
  <td><a href="https://github.com/cbkii/arrbash/pull/83/files#diff-e52229475913ead2a19b9c4be787d753170d054136228f98c3e427452e7bc2ca">+8/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically normalises the OpenVPN username to include the “+pmp” suffix when missing, with a flag indicating if it was added.
- Bug Fixes
  - More reliable handling of quoted environment variable values, preventing misparsing.
  - Strips stray carriage returns from credential values to avoid authentication issues.
- Improvements
  - More robust retrieval of credentials from configuration, with safe defaults and fewer parsing errors.
- Chores
  - Removed legacy parsing logic in favour of a unified, cleaner credential-reading flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->